### PR TITLE
Keter fails to build if tar < 0.4

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -28,9 +28,9 @@ Library
                      , data-default
                      , filepath
                      , zlib
-                     , tar
                      , network
                      , time
+                     , tar                       >= 0.4
                      , template-haskell
                      , blaze-builder             >= 0.3           && < 0.4
                      , yaml                      >= 0.7           && < 0.9


### PR DESCRIPTION
Keter fails to install when tar is too old. It outputs:

Keter/App.hs:161:38: 
    Not in scope: type constructor or class `Tar.FormatError'

should be fixed by putting a minimum on the version of tar in keter.cabal.
