### PR TITLE
Add a configurable timeout to ReverseProxy, fix optional ssl

### DIFF
--- a/Keter/ReverseProxy.hs
+++ b/Keter/ReverseProxy.hs
@@ -41,9 +41,6 @@ import qualified Network.Wai as Wai
 import Network.HTTP.Conduit
 import Network.HTTP.Types
 
-import qualified Data.Conduit.List as CL
-import Control.Monad.IO.Class (liftIO, MonadIO (..))
-
 data ReverseProxyConfig = ReverseProxyConfig
     { reversedHost :: Text
     , reversedPort :: Int


### PR DESCRIPTION
As said in title, this adds a timeout option that was previously absent and fixes the ssl parameter, it should have been optional but was required,
