### PR TITLE
Remove upper bound on http-reverse-proxy

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -43,7 +43,7 @@ Library
                      , conduit                   >= 0.5
                      , network-conduit           >= 0.6
                      , network-conduit-tls       >= 1.0.0.2
-                     , http-reverse-proxy        >= 0.1.0.2       && < 0.2
+                     , http-reverse-proxy        >= 0.1.0.2
                      , unix-process-conduit      >= 0.2           && < 0.3
                      , unix                      >= 2.5           && < 2.7
                      , wai-app-static            >= 1.3           && < 1.4


### PR DESCRIPTION
To allow building with http-reverse-proxy 0.2.0.
