### PR TITLE
Add missing lifted-base package dependency

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -34,6 +34,7 @@ Library
                      , zlib
                      , network
                      , time
+                     , lifted-base               >= 0.2           && < 0.3
                      , tar                       >= 0.4
                      , template-haskell
                      , blaze-builder             >= 0.3           && < 0.4


### PR DESCRIPTION
Keter fails to install when missing lifted-base package dependency.

``` bash
$ cabal-dev install keter
```

got ExitFailure 1.
it outputs:

```
...
Configuring classy-prelude-0.5.0...
Building classy-prelude-0.5.0...
Preprocessing library classy-prelude-0.5.0...

ClassyPrelude.hs:122:8:
    Could not find module `Data.IORef.Lifted'
    Use -v to see a list of the files searched for.
...
cabal: Error: some packages failed to install:
classy-prelude-0.5.0 failed during the building phase. The exception was:
ExitFailure 1
http-reverse-proxy-0.2.0 depends on classy-prelude-0.5.0 which failed to
install.
keter-0.4.0 depends on classy-prelude-0.5.0 which failed to install.
```

Classy-prelude seems to be importing  module 'Data.IORef.Lifted'.
 And 'Data.IORef.Lifted' module exports lifted-base-0.2.1.0.

should be fixed by adding dependency of lifted-base in keter.cabal.
