### PR TITLE
make args in example config in readme on separate lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ configuration:
 ```yaml
 exec: ../com.example.app
 args:
-    - Hello World 1
+    - Hello
+    - World
+    - 1
 host: www.example.com
 extra-hosts:
     - "*.example.com"


### PR DESCRIPTION
@snoyberg - I'm not sure if this is what you had in mind, but this is the only place in the readme I saw args mentioned, and seeing whitespace separated non-quoted arguments made me thing that it was similar to a shell. If I had seen a list of them, I would not have thought that... 
