### PR TITLE
fix usage message to ask for path to config file, not root folder

### DIFF
--- a/main/keter.hs
+++ b/main/keter.hs
@@ -19,4 +19,4 @@ main = do
             [\configDir -> Postgres.load def $ configDir </> "etc" </> "postgres.yaml"]
         _ -> do
             pn <- getProgName
-            error $ "Usage: " ++ pn ++ " <root folder>"
+            error $ "Usage: " ++ pn ++ " <config file>"


### PR DESCRIPTION
The error when you run just the keter binary incorrectly says you should put the path to the root folder, which confused me for a while. The documentation in the README is correct, but the usage message should be authoritative (I may be odd, but I only went and checked the README after reading the source, figuring out what I should have done, and then checking to see if the mistake was present in the docs as well).
