### PR TITLE
Print usage when passed `--help`

### DIFF
--- a/main/keter.hs
+++ b/main/keter.hs
@@ -14,9 +14,13 @@ main = do
     args <- getArgs
     case args of
         ["--version"] -> putStrLn $ "keter version: " ++ showVersion version
+        ["--help"] -> printUsage
         [dir] -> keter
             (decodeString dir)
             [\configDir -> Postgres.load def $ configDir </> "etc" </> "postgres.yaml"]
-        _ -> do
-            pn <- getProgName
-            error $ "Usage: " ++ pn ++ " <config file>"
+        _ -> printUsage
+
+printUsage :: IO ()
+printUsage = do
+    pn <- getProgName
+    error $ "Usage: " ++ pn ++ " <config file>"


### PR DESCRIPTION
I was pretty surprised when keter started bundling when passed `--help`, since that's a pretty standard flag.
