### PR TITLE
Add global setting per Keter global envoriment

### DIFF
--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -269,11 +269,12 @@ launchWebApp AppStartConfig {..} aid BundleConfig {..} mdir rlog WebAppConfig {.
     otherEnv <- pluginsGetEnv ascPlugins name bconfigPlugins
     let httpPort  = kconfigExternalHttpPort  ascKeterConfig
         httpsPort = kconfigExternalHttpsPort ascKeterConfig
+        keterEnv  = Map.toList $ kconfigEnvironment ascKeterConfig
         (scheme, extport) =
             if waconfigSsl
                 then ("https://", if httpsPort == 443 then "" else ':' : show httpsPort)
                 else ("http://",  if httpPort  ==  80 then "" else ':' : show httpPort)
-        env = ("PORT", pack $ show waconfigPort)
+        env = keterEnv ++ ("PORT", pack $ show waconfigPort)
             : ("APPROOT", scheme <> CI.original waconfigApprootHost <> pack extport)
             : Map.toList waconfigEnvironment ++ otherEnv
     exec <- canonicalizePath waconfigExec

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -93,6 +93,7 @@ data KeterConfig = KeterConfig
     -- ^ External HTTP port when generating APPROOTs.
     , kconfigExternalHttpsPort :: !Int
     -- ^ External HTTPS port when generating APPROOTs.
+    , kconfigEnvironment :: !(Map Text Text)
     }
 
 instance ToCurrent KeterConfig where
@@ -106,6 +107,7 @@ instance ToCurrent KeterConfig where
         , kconfigIpFromHeader = ipFromHeader
         , kconfigExternalHttpPort = 80
         , kconfigExternalHttpsPort = 443
+        , kconfigEnvironment = Map.empty
         }
       where
         getSSL Nothing = V.empty
@@ -125,6 +127,7 @@ instance Default KeterConfig where
         , kconfigIpFromHeader = False
         , kconfigExternalHttpPort = 80
         , kconfigExternalHttpsPort = 443
+        , kconfigEnvironment = Map.empty
         }
 
 instance ParseYamlFile KeterConfig where
@@ -143,6 +146,7 @@ instance ParseYamlFile KeterConfig where
             <*> o .:? "ip-from-header" .!= False
             <*> o .:? "external-http-port" .!= 80
             <*> o .:? "external-https-port" .!= 443
+            <*> o .:? "env" .!= Map.empty
 
 data Stanza port
     = StanzaStaticFiles !StaticFilesConfig


### PR DESCRIPTION
Which will be passed to all children processes.

Usefull if we want to move server specific settings out of local (application) configs.

It goes on top level of the main 

```
#keter-config.yaml
env:
       WRITABLE_DIR_PATH: /home/marcin/keter/permanent/
```
