### PR TITLE
Forward environment variables from the shell that executes keter

### DIFF
--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -327,6 +327,7 @@ data WebAppConfig port = WebAppConfig
     , waconfigHosts       :: !(Set Host) -- ^ all hosts, not including the approot host
     , waconfigSsl         :: !Bool
     , waconfigPort        :: !port
+    , waconfigForwardEnv  :: !(Set Text)
     }
     deriving Show
 
@@ -340,6 +341,7 @@ instance ToCurrent (WebAppConfig ()) where
         , waconfigHosts = Set.map CI.mk hosts
         , waconfigSsl = ssl
         , waconfigPort = ()
+        , waconfigForwardEnv = Set.empty
         }
 
 instance ParseYamlFile (WebAppConfig ()) where
@@ -361,6 +363,7 @@ instance ParseYamlFile (WebAppConfig ()) where
             <*> return hosts
             <*> o .:? "ssl" .!= False
             <*> return ()
+            <*> o .:? "forward-env" .!= Set.empty
 
 instance ToJSON (WebAppConfig ()) where
     toJSON WebAppConfig {..} = object
@@ -369,6 +372,7 @@ instance ToJSON (WebAppConfig ()) where
         , "env" .= waconfigEnvironment
         , "hosts" .= map CI.original (waconfigApprootHost : Set.toList waconfigHosts)
         , "ssl" .= waconfigSsl
+        , "forward-env" .= waconfigForwardEnv
         ]
 
 data AppInput = AIBundle !FilePath !EpochTime

--- a/incoming/foo1_0/config/keter.yaml
+++ b/incoming/foo1_0/config/keter.yaml
@@ -5,6 +5,9 @@ stanzas:
         - Hello World 2
       env:
         FROM_KETER_CONFIG: foo bar baz
+      forward-env:
+        - FROM_SYSTEM_ENV
+        - ANOTHER_ENV_VAR
       hosts:
         - keter1_0
         - pong1_0


### PR DESCRIPTION
It is often convenient to store secrets in environment variables on the host system. This patch allows those secrets to be passed along to the sub processes executed by keter.

Specifically I'm attempting to run keter from inside a docker container. This allows the web app to easily read environment vars that are set by docker identifiying linked containers as well as environment variables that are passed into the container when it is run.
