### PR TITLE
Fix warnings in build.

### DIFF
--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -12,7 +12,7 @@ import           Control.Monad.IO.Class            (liftIO)
 import qualified Data.ByteString                   as S
 import qualified Data.ByteString.Char8             as S8
 import qualified Data.CaseInsensitive              as CI
-import           Data.Default
+import           Data.Default                      (Default(..))
 import           Data.Monoid                       (mappend, mempty)
 import           Data.Text.Encoding                (encodeUtf8, decodeUtf8With)
 import           Data.Text.Encoding.Error          (lenientDecode)
@@ -35,7 +35,7 @@ import           Network.Wai.Application.Static    (defaultFileServerSettings,
                                                     ssListing, staticApp)
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Handler.WarpTLS       as WarpTLS
-import           Network.Wai.Middleware.Gzip       (gzip, def)
+import           Network.Wai.Middleware.Gzip       (gzip)
 import           Prelude                           hiding (FilePath, (++))
 import           WaiAppStatic.Listing              (defaultListing)
 import System.Timeout.Lifted (timeout)

--- a/Keter/Types/V04.hs
+++ b/Keter/Types/V04.hs
@@ -17,7 +17,6 @@ import qualified Network.Wai.Handler.WarpTLS as WarpTLS
 import Filesystem.Path.CurrentOS (encodeString)
 import Keter.Types.Common
 import Network.HTTP.ReverseProxy.Rewrite
-import qualified Data.Text as T
 
 data AppConfig = AppConfig
     { configExec :: F.FilePath


### PR DESCRIPTION
- In Keter.Proxy explicitly import Default typeclass.
- Remove unused qualified Text impot in Keter.Types.V04.
