### PR TITLE
Fix link to setup-keter.sh in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ allows for easy management of your web apps.
 
 Do get Keter up-and-running quickly on an Ubuntu system, run:
 
-    wget -O - https://raw.github.com/snoyberg/keter/master/setup-keter.sh | bash
+    wget -O - https://raw.githubusercontent.com/snoyberg/keter/master/setup-keter.sh | bash
 
 (Note: you may need to run the above command twice, if the shell exits after
 `apt-get` but before running the rest of its instructions.) This will download


### PR DESCRIPTION
The link to setup-keter.sh seems to be incorrect.  It appears that raw
file content is now served from https://raw.githubusercontent.com/.
