### PR TITLE
Support chain certificates in credentials

### DIFF
--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -53,8 +53,11 @@ reverseProxy useHeader manager hostLookup listener =
     (run, isSecure) =
         case listener of
             LPInsecure host port -> (Warp.runSettings (warp host port), False)
-            LPSecure host port cert key -> (WarpTLS.runTLS
-                (WarpTLS.tlsSettings (F.encodeString cert) (F.encodeString key))
+            LPSecure host port cert chainCerts key -> (WarpTLS.runTLS
+                (WarpTLS.tlsSettingsChain
+                    (F.encodeString cert)
+                    (map F.encodeString $ V.toList chainCerts)
+                    (F.encodeString key))
                 (warp host port), True)
 
 withClient :: Bool -- ^ is secure?

--- a/keter.cabal
+++ b/keter.cabal
@@ -54,7 +54,7 @@ Library
                      , array
                      , mtl
                      , warp
-                     , warp-tls
+                     , warp-tls                  >= 3.0.2.1
                      , aeson
                      , unordered-containers
                      , vector


### PR DESCRIPTION
Add support for chain certificates. This PR depends on yesodweb/wai#349 which adds chain certificate support to warp-tls. This PR takes a wild guess and sets the dependency bound on warp-tls to >= 3.0.2.1.