### PR TITLE
network-conduit-tls is no longer needed.

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -39,7 +39,6 @@ Library
                      , system-fileio             >= 0.3           && < 0.4
                      , conduit                   >= 1.1
                      , conduit-extra             >= 1.1
-                     , network-conduit-tls       >= 1.1
                      , http-reverse-proxy        >= 0.4           && < 0.5
                      , unix                      >= 2.5
                      , wai-app-static            >= 3.0           && < 3.1


### PR DESCRIPTION
As discussed in #83, the dependency on network-conduit-tls now seems unused. keter built fine for me without it.