### PR TITLE
lowercase app name when generating postgres db name

### DIFF
--- a/Keter/Plugin/Postgres.hs
+++ b/Keter/Plugin/Postgres.hs
@@ -21,6 +21,7 @@ import           Data.Default
 import qualified Data.HashMap.Strict       as HMap
 import qualified Data.Map                  as Map
 import           Data.Monoid               ((<>))
+import qualified Data.Char                 as C
 import qualified Data.Text                 as T
 import qualified Data.Text.Lazy            as TL
 import           Data.Text.Lazy.Builder    (fromText, toLazyText)
@@ -142,7 +143,7 @@ load Settings{..} fp = do
 
     sanitize = T.map sanitize'
     sanitize' c
-        | 'A' <= c && c <= 'Z' = c
+        | 'A' <= c && c <= 'Z' = C.toLower c
         | 'a' <= c && c <= 'z' = c
         | '0' <= c && c <= '9' = c
         | otherwise = '_'

--- a/Keter/Plugin/Postgres.hs
+++ b/Keter/Plugin/Postgres.hs
@@ -13,8 +13,7 @@ import           Control.Concurrent        (forkIO)
 import           Control.Concurrent.Chan
 import           Control.Concurrent.MVar
 import           Control.Exception         (throwIO, try)
-import           Control.Monad             (void)
-import           Control.Monad             (forever, mzero, replicateM)
+import           Control.Monad             (forever, mzero, replicateM, void)
 import           Control.Monad.Trans.Class (lift)
 import qualified Control.Monad.Trans.State as S
 import           Data.Default
@@ -102,7 +101,7 @@ load Settings{..} fp = do
         -- FIXME stop using the worker thread approach?
         void $ forkIO $ flip S.evalStateT (db0, g0) $ forever $ loop chan
         return Plugin
-            { pluginGetEnv = \appname o -> do
+            { pluginGetEnv = \appname o ->
                 case HMap.lookup "postgres" o of
                     Just (Bool True) -> do
                         x <- newEmptyMVar


### PR DESCRIPTION
Lowercase appname when generating db name in postgres plugin
Branch made from issue #86 
supersede pr #87

also applied Hlint suggestion
- remove redundant `do`
- merge two imports statements into one