### PR TITLE
Add configurable timeouts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+* Drop system-filepath
+
 ## 1.3.10
 
 * Configurable time bound [#92](https://github.com/snoyberg/keter/pull/92)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.0.1
+
+* Avoid infinite loop traversing incoming directory [#96](https://github.com/snoyberg/keter/issues/96)
+
 ## 1.4.0
 
 * Drop system-filepath

--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -18,7 +18,7 @@ import           Control.Concurrent        (forkIO, threadDelay)
 import           Control.Concurrent.STM
 import           Control.Exception         (IOException, bracketOnError,
                                             throwIO, try)
-import           Control.Monad             (void, when)
+import           Control.Monad             (void, when, unless)
 import qualified Data.CaseInsensitive      as CI
 import           Data.Conduit.LogFile      (RotatingLog)
 import qualified Data.Conduit.LogFile      as LogFile
@@ -47,8 +47,7 @@ import           Prelude                   hiding (FilePath)
 import           System.Environment        (getEnvironment)
 import           System.IO                 (hClose)
 import           System.Posix.Files        (fileAccess)
-import           System.Posix.Types        (EpochTime)
-import           System.Posix.Types        (GroupID, UserID)
+import           System.Posix.Types        (EpochTime, GroupID, UserID)
 import           System.Timeout            (timeout)
 
 data App = App
@@ -145,7 +144,7 @@ withActions asc bconfig f =
             stanzas
             (wac { waconfigPort = port } : wacs)
             backs
-            (Map.unions $ actions : map (\host -> Map.singleton host (PAPort port, rs)) hosts))
+            (Map.unions $ actions : map (\host -> Map.singleton host (PAPort port (waconfigTimeout wac), rs)) hosts))
       where
         hosts = Set.toList $ Set.insert (waconfigApprootHost wac) (waconfigHosts wac)
     loop (Stanza (StanzaStaticFiles sfc) rs:stanzas) wacs backs actions0 =
@@ -162,10 +161,10 @@ withActions asc bconfig f =
                 $ actions0
                 : map (\host -> Map.singleton host (PARedirect red, rs))
                   (Set.toList (redirconfigHosts red))
-    loop (Stanza (StanzaReverseProxy rev) rs:stanzas) wacs backs actions0 =
+    loop (Stanza (StanzaReverseProxy rev mid to) rs:stanzas) wacs backs actions0 =
         loop stanzas wacs backs actions
       where
-        actions = Map.insert (CI.mk $ reversingHost rev) (PAReverseProxy rev, rs) actions0
+        actions = Map.insert (CI.mk $ reversingHost rev) (PAReverseProxy rev mid to, rs) actions0
     loop (Stanza (StanzaBackground back) _:stanzas) wacs backs actions =
         loop stanzas wacs (back:backs) actions
 
@@ -279,7 +278,7 @@ launchWebApp AppStartConfig {..} aid BundleConfig {..} mdir rlog WebAppConfig {.
             -- Ordering chosen specifically to precedence rules: app specific,
             -- plugins, global, and then auto-set Keter variables.
             [ waconfigEnvironment
-            , Map.filterWithKey (\k _ -> Set.member k waconfigForwardEnv) $ Map.fromList $ map (\x -> (pack (fst x), pack (snd x))) systemEnv
+            , Map.filterWithKey (\k _ -> Set.member k waconfigForwardEnv) $ Map.fromList $ map (pack *** pack) systemEnv
             , Map.fromList otherEnv
             , kconfigEnvironment ascKeterConfig
             , Map.singleton "PORT" $ pack $ show waconfigPort

--- a/Keter/AppManager.hs
+++ b/Keter/AppManager.hs
@@ -25,7 +25,6 @@ import qualified Data.Map                  as Map
 import           Data.Maybe                (mapMaybe)
 import           Data.Maybe                (catMaybes)
 import qualified Data.Set                  as Set
-import qualified Filesystem.Path.CurrentOS as F
 import           Keter.App                 (App, AppStartConfig)
 import qualified Keter.App                 as App
 import           Keter.Types
@@ -247,7 +246,7 @@ addApp appMan bundle = do
 
 getInputForBundle :: FilePath -> IO (AppId, Action)
 getInputForBundle bundle = do
-    time <- modificationTime <$> getFileStatus (F.encodeString bundle)
+    time <- modificationTime <$> getFileStatus bundle
     return (AINamed $ getAppname bundle, Reload $ AIBundle bundle time)
 
 terminateApp :: AppManager -> Appname -> IO ()

--- a/Keter/Main.hs
+++ b/Keter/Main.hs
@@ -186,7 +186,7 @@ listDirectoryTree fp = do
              listDirectoryTree fp1
            else
              return [fp1]
-           ) dir
+           ) (filter (\x -> x /= "." && x /= "..") dir)
 
 startListening :: KeterConfig -> HostMan.HostManager -> IO ()
 startListening KeterConfig {..} hostman = do

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -17,7 +17,6 @@ import           Data.Monoid                       (mappend, mempty)
 import           Data.Text.Encoding                (decodeUtf8With, encodeUtf8)
 import           Data.Text.Encoding.Error          (lenientDecode)
 import qualified Data.Vector                       as V
-import qualified Filesystem.Path.CurrentOS         as F
 import           Keter.Types
 import           Keter.Types.Middleware
 import           Network.HTTP.Conduit              (Manager)
@@ -55,9 +54,9 @@ reverseProxy useHeader timeBound manager hostLookup listener =
             LPInsecure host port -> (Warp.runSettings (warp host port), False)
             LPSecure host port cert chainCerts key -> (WarpTLS.runTLS
                 (WarpTLS.tlsSettingsChain
-                    (F.encodeString cert)
-                    (map F.encodeString $ V.toList chainCerts)
-                    (F.encodeString key))
+                    cert
+                    (V.toList chainCerts)
+                    key)
                 (warp host port), True)
 
 withClient :: Bool -- ^ is secure?

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TupleSections   #-}
 -- | A light-weight, minimalistic reverse HTTP proxy.
 module Keter.Proxy
     ( reverseProxy
@@ -8,6 +9,7 @@ module Keter.Proxy
     ) where
 
 import           Blaze.ByteString.Builder          (copyByteString)
+import           Control.Applicative               ((<|>))
 import           Control.Monad.IO.Class            (liftIO)
 import qualified Data.ByteString                   as S
 import qualified Data.ByteString.Char8             as S8
@@ -23,7 +25,7 @@ import           Network.HTTP.Conduit              (Manager)
 import           Network.HTTP.ReverseProxy         (ProxyDest (ProxyDest),
                                                     SetIpHeader (..),
                                                     WaiProxyResponse (..),
-                                                    waiProxyToSettings,
+                                                    waiProxyToSettingsWithTimeouts,
                                                     wpsSetIpHeader)
 import qualified Network.HTTP.ReverseProxy.Rewrite as Rewrite
 import           Network.HTTP.Types                (mkStatus, status200,
@@ -65,17 +67,14 @@ withClient :: Bool -- ^ is secure?
            -> Manager
            -> HostLookup
            -> Wai.Application
-withClient isSecure useHeader bound manager portLookup req0 sendResponse =
-    if bound > 0
-       then timeBound (bound * 1000) task
-       else task
-  where
-    task = waiProxyToSettings getDest def
+withClient isSecure useHeader bound manager hostLookup =
+    waiProxyToSettingsWithTimeouts getDest def
         { wpsSetIpHeader =
             if useHeader
                 then SIHFromHeader
                 else SIHFromSocket
-        } manager req0 sendResponse
+        } manager
+  where
     protocol
         | isSecure = "https"
         | otherwise = "http"
@@ -87,39 +86,38 @@ withClient isSecure useHeader bound manager portLookup req0 sendResponse =
     -- infinitely without the server it's connecting to going down, so that
     -- requires more research. Meanwhile, this prevents the file descriptor
     -- leak from occurring.
-    timeBound us f = do
-        mres <- timeout us f
-        case mres of
-            Just res -> return res
-            Nothing -> sendResponse $ Wai.responseLBS status500 [] "timeBound"
 
-    getDest :: Wai.Request -> IO WaiProxyResponse
+    fixTimeBound :: Maybe Int -> Maybe Int
+    fixTimeBound to = case to <|> Just bound of
+          Just x | x > 0 -> Just x
+          _              -> Nothing
+    getDest :: Wai.Request -> IO (Maybe Int, WaiProxyResponse)
     getDest req =
         case Wai.requestHeaderHost req of
-            Nothing -> return $ WPRResponse missingHostResponse
+            Nothing -> return (Nothing, WPRResponse missingHostResponse)
             Just host -> processHost req host
 
-    processHost :: Wai.Request -> S.ByteString -> IO WaiProxyResponse
+    processHost :: Wai.Request -> S.ByteString -> IO (Maybe Int, WaiProxyResponse)
     processHost req host = do
         -- Perform two levels of lookup. First: look up the entire host. If
         -- that fails, try stripping off any port number and try again.
         mport <- liftIO $ do
-            mport1 <- portLookup host
+            mport1 <- hostLookup host
             case mport1 of
                 Just _ -> return mport1
                 Nothing -> do
                     let host' = S.takeWhile (/= 58) host
                     if host' == host
                         then return Nothing
-                        else portLookup host'
+                        else hostLookup host'
         case mport of
-            Nothing -> return $ WPRResponse $ unknownHostResponse host
+            Nothing -> return (Nothing, WPRResponse $ unknownHostResponse host)
             Just (action, requiresSecure)
                 | requiresSecure && not isSecure -> performHttpsRedirect host req
                 | otherwise -> performAction req action
 
     performHttpsRedirect host =
-        return . WPRResponse . redirectApp config
+        return . (fixTimeBound Nothing,) . WPRResponse . redirectApp config
       where
         host' = CI.mk $ decodeUtf8With lenientDecode host
         config = RedirectConfig
@@ -129,22 +127,23 @@ withClient isSecure useHeader bound manager portLookup req0 sendResponse =
                                  $ RDPrefix True host' Nothing
             }
 
-    performAction req (PAPort port) =
-        return $ WPRModifiedRequest req' $ ProxyDest "127.0.0.1" port
+    performAction req (PAPort port tbound) =
+        return (fixTimeBound tbound, WPRModifiedRequest req' $ ProxyDest "127.0.0.1" port)
       where
         req' = req
             { Wai.requestHeaders = ("X-Forwarded-Proto", protocol)
                                  : Wai.requestHeaders req
             }
-    performAction _ (PAStatic StaticFilesConfig {..}) = do
-        return $ WPRApplication $ processMiddleware sfconfigMiddleware $ staticApp (defaultFileServerSettings sfconfigRoot)
+    performAction _ (PAStatic StaticFilesConfig {..}) =
+        return (fixTimeBound sfconfigTimeout, WPRApplication $ processMiddleware sfconfigMiddleware $ staticApp (defaultFileServerSettings sfconfigRoot)
             { ssListing =
                 if sfconfigListings
                     then Just defaultListing
                     else Nothing
-            }
-    performAction req (PARedirect config) = return $ WPRResponse $ redirectApp config req
-    performAction _ (PAReverseProxy config) = return $ WPRApplication $ Rewrite.simpleReverseProxy manager config
+            })
+    performAction req (PARedirect config) = return (fixTimeBound Nothing, WPRResponse $ redirectApp config req)
+    performAction _ (PAReverseProxy config rpconfigMiddleware tbound) =
+       return (fixTimeBound tbound, WPRApplication $ processMiddleware rpconfigMiddleware $ Rewrite.simpleReverseProxy manager config)
 
 redirectApp :: RedirectConfig -> Wai.Request -> Wai.Response
 redirectApp RedirectConfig {..} req =

--- a/Keter/Types/Common.hs
+++ b/Keter/Types/Common.hs
@@ -22,11 +22,9 @@ import qualified Data.Set                   as Set
 import           Data.Text                  (Text, pack, unpack)
 import           Data.Typeable              (Typeable)
 import qualified Data.Yaml
-import           Filesystem.Path.CurrentOS  (FilePath, basename, encodeString,
-                                             toText)
 import qualified Language.Haskell.TH.Syntax as TH
-import           Prelude                    hiding (FilePath)
 import           System.Exit                (ExitCode)
+import           System.FilePath            (takeBaseName)
 
 -- | Name of the application. Should just be the basename of the application
 -- file.
@@ -55,7 +53,7 @@ type Host = CI Text
 type HostBS = CI ByteString
 
 getAppname :: FilePath -> Text
-getAppname = either id id . toText . basename
+getAppname = pack . takeBaseName
 
 data LogMessage
     = ProcessCreated FilePath
@@ -81,16 +79,16 @@ data LogMessage
     | WatchedFile Text FilePath
 
 instance Show LogMessage where
-    show (ProcessCreated f) = "Created process: " ++ encodeString f
+    show (ProcessCreated f) = "Created process: " ++ f
     show (InvalidBundle f e) = concat
         [ "Unable to parse bundle file '"
-        , encodeString f
+        , f
         , "': "
         , show e
         ]
     show (ProcessDidNotStart fp) = concat
         [ "Could not start process within timeout period: "
-        , encodeString fp
+        , fp
         ]
     show (ExceptionThrown t e) = concat
         [ unpack t
@@ -100,16 +98,16 @@ instance Show LogMessage where
     show (RemovingPort p) = "Port in use, removing from port pool: " ++ show p
     show (UnpackingBundle b) = concat
         [ "Unpacking bundle '"
-        , encodeString b
+        , b
         , "'"
         ]
     show (TerminatingApp t) = "Shutting down app: " ++ unpack t
     show (FinishedReloading t) = "App finished reloading: " ++ unpack t
     show (TerminatingOldProcess (AINamed t)) = "Sending old process TERM signal: " ++ unpack t
     show (TerminatingOldProcess AIBuiltin) = "Sending old process TERM signal: builtin"
-    show (RemovingOldFolder fp) = "Removing unneeded folder: " ++ encodeString fp
+    show (RemovingOldFolder fp) = "Removing unneeded folder: " ++ fp
     show (ReceivedInotifyEvent t) = "Received unknown INotify event: " ++ unpack t
-    show (ProcessWaiting f) = "Process restarting too quickly, waiting before trying again: " ++ encodeString f
+    show (ProcessWaiting f) = "Process restarting too quickly, waiting before trying again: " ++ f
     show (OtherMessage t) = unpack t
     show (ErrorStartingBundle name e) = concat
         [ "Error occured when launching bundle "
@@ -135,7 +133,7 @@ instance Show LogMessage where
         [ "Watched file "
         , unpack action
         , ": "
-        , encodeString fp
+        , fp
         ]
 
 data KeterException = CannotParsePostgres FilePath

--- a/Keter/Types/V04.hs
+++ b/Keter/Types/V04.hs
@@ -10,8 +10,7 @@ import           Data.Default
 import qualified Data.Set                          as Set
 import           Data.String                       (fromString)
 import           Data.Yaml.FilePath
-import qualified Filesystem.Path                   as F
-import           Filesystem.Path.CurrentOS         (encodeString)
+import qualified System.FilePath                   as F
 import           Keter.Types.Common
 import           Network.HTTP.ReverseProxy.Rewrite
 import qualified Network.Wai.Handler.Warp          as Warp
@@ -124,8 +123,8 @@ instance ParseYamlFile TLSConfig where
             $ Warp.setPort port
               Warp.defaultSettings)
             WarpTLS.defaultTlsSettings
-                { WarpTLS.certFile = encodeString cert
-                , WarpTLS.keyFile = encodeString key
+                { WarpTLS.certFile = cert
+                , WarpTLS.keyFile = key
                 }
 
 -- | Controls execution of the nginx thread. Follows the settings type pattern.

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -53,7 +53,7 @@ instance ToCurrent BundleConfig where
         }
 
 instance ParseYamlFile BundleConfig where
-    parseYamlFile basedir = withObject "BundleConfig" $ \o -> do
+    parseYamlFile basedir = withObject "BundleConfig" $ \o ->
         case HashMap.lookup "stanzas" o of
             Nothing -> (toCurrent :: V04.BundleConfig -> BundleConfig) <$> parseYamlFile basedir (Object o)
             Just _ -> current o
@@ -111,7 +111,7 @@ instance ToCurrent KeterConfig where
         , kconfigPortPool = portman
         , kconfigListeners = NonEmptyVector (LPInsecure host port) (getSSL ssl)
         , kconfigSetuid = setuid
-        , kconfigBuiltinStanzas = V.fromList $ map (flip Stanza False . StanzaReverseProxy) $ Set.toList rproxy
+        , kconfigBuiltinStanzas = V.fromList $ map (flip Stanza False . (\rp -> StanzaReverseProxy rp [] Nothing)) $ Set.toList rproxy
         , kconfigIpFromHeader = ipFromHeader
         , kconfigExternalHttpPort = 80
         , kconfigExternalHttpsPort = 443
@@ -169,7 +169,7 @@ data StanzaRaw port
     = StanzaStaticFiles !StaticFilesConfig
     | StanzaRedirect !RedirectConfig
     | StanzaWebApp !(WebAppConfig port)
-    | StanzaReverseProxy !ReverseProxyConfig
+    | StanzaReverseProxy !ReverseProxyConfig ![ MiddlewareConfig ] !(Maybe Int)
     | StanzaBackground !BackgroundConfig
             -- FIXME console app
     deriving Show
@@ -182,10 +182,10 @@ data StanzaRaw port
 --
 -- 2. Not all stanzas have an associated proxy action.
 data ProxyActionRaw
-    = PAPort Port
+    = PAPort Port !(Maybe Int)
     | PAStatic StaticFilesConfig
     | PARedirect RedirectConfig
-    | PAReverseProxy ReverseProxyConfig
+    | PAReverseProxy ReverseProxyConfig ![ MiddlewareConfig ] !(Maybe Int)
     deriving Show
 
 type ProxyAction = (ProxyActionRaw, RequiresSecure)
@@ -195,11 +195,13 @@ instance ParseYamlFile (Stanza ()) where
         typ <- o .: "type"
         needsHttps <- o .:? "requires-secure" .!= False
         raw <- case typ of
-            "static-files" -> fmap StanzaStaticFiles $ parseYamlFile basedir $ Object o
-            "redirect" -> fmap StanzaRedirect $ parseYamlFile basedir $ Object o
-            "webapp" -> fmap StanzaWebApp $ parseYamlFile basedir $ Object o
-            "reverse-proxy" -> fmap StanzaReverseProxy $ parseJSON $ Object o
-            "background" -> fmap StanzaBackground $ parseYamlFile basedir $ Object o
+            "static-files"  -> fmap StanzaStaticFiles $ parseYamlFile basedir $ Object o
+            "redirect"      -> fmap StanzaRedirect $ parseYamlFile basedir $ Object o
+            "webapp"        -> fmap StanzaWebApp $ parseYamlFile basedir $ Object o
+            "reverse-proxy" -> StanzaReverseProxy <$> parseJSON (Object o)
+                                                  <*> o .:? "middleware" .!= []
+                                                  <*> o .:? "connection-time-bound"
+            "background"    -> fmap StanzaBackground $ parseYamlFile basedir $ Object o
             _ -> fail $ "Unknown stanza type: " ++ typ
         return $ Stanza raw needsHttps
 
@@ -216,7 +218,7 @@ instance ToJSON (StanzaRaw ()) where
     toJSON (StanzaStaticFiles x) = addStanzaType "static-files" x
     toJSON (StanzaRedirect x) = addStanzaType "redirect" x
     toJSON (StanzaWebApp x) = addStanzaType "webapp" x
-    toJSON (StanzaReverseProxy x) = addStanzaType "reverse-proxy" x
+    toJSON (StanzaReverseProxy x _ _) = addStanzaType "reverse-proxy" x
     toJSON (StanzaBackground x) = addStanzaType "background" x
 
 addStanzaType :: ToJSON a => Value -> a -> Value
@@ -231,16 +233,18 @@ data StaticFilesConfig = StaticFilesConfig
     , sfconfigListings   :: !Bool
     -- FIXME basic auth
     , sfconfigMiddleware :: ![ MiddlewareConfig ]
+    , sfconfigTimeout    :: !(Maybe Int)
     }
     deriving Show
 
 instance ToCurrent StaticFilesConfig where
     type Previous StaticFilesConfig = V04.StaticHost
     toCurrent (V04.StaticHost host root) = StaticFilesConfig
-        { sfconfigRoot = root
-        , sfconfigHosts = Set.singleton $ CI.mk host
-        , sfconfigListings = True
+        { sfconfigRoot       = root
+        , sfconfigHosts      = Set.singleton $ CI.mk host
+        , sfconfigListings   = True
         , sfconfigMiddleware = []
+        , sfconfigTimeout    = Nothing
         }
 
 instance ParseYamlFile StaticFilesConfig where
@@ -249,6 +253,7 @@ instance ParseYamlFile StaticFilesConfig where
         <*> (Set.map CI.mk <$> ((o .: "hosts" <|> (Set.singleton <$> (o .: "host")))))
         <*> o .:? "directory-listing" .!= False
         <*> o .:? "middleware" .!= []
+        <*> o .:? "connection-time-bound"
 
 instance ToJSON StaticFilesConfig where
     toJSON StaticFilesConfig {..} = object
@@ -256,6 +261,7 @@ instance ToJSON StaticFilesConfig where
         , "hosts" .= Set.map CI.original sfconfigHosts
         , "directory-listing" .= sfconfigListings
         , "middleware" .= sfconfigMiddleware
+        , "connection-time-bound" .= sfconfigTimeout
         ]
 
 data RedirectConfig = RedirectConfig
@@ -343,6 +349,7 @@ data WebAppConfig port = WebAppConfig
     , waconfigSsl         :: !Bool
     , waconfigPort        :: !port
     , waconfigForwardEnv  :: !(Set Text)
+    , waconfigTimeout     :: !(Maybe Int)
     }
     deriving Show
 
@@ -357,6 +364,7 @@ instance ToCurrent (WebAppConfig ()) where
         , waconfigSsl = ssl
         , waconfigPort = ()
         , waconfigForwardEnv = Set.empty
+        , waconfigTimeout = Nothing
         }
 
 instance ParseYamlFile (WebAppConfig ()) where
@@ -379,6 +387,7 @@ instance ParseYamlFile (WebAppConfig ()) where
             <*> o .:? "ssl" .!= False
             <*> return ()
             <*> o .:? "forward-env" .!= Set.empty
+            <*> o .:? "connection-time-bound"
 
 instance ToJSON (WebAppConfig ()) where
     toJSON WebAppConfig {..} = object
@@ -388,6 +397,7 @@ instance ToJSON (WebAppConfig ()) where
         , "hosts" .= map CI.original (waconfigApprootHost : Set.toList waconfigHosts)
         , "ssl" .= waconfigSsl
         , "forward-env" .= waconfigForwardEnv
+        , "connection-time-bound" .= waconfigTimeout
         ]
 
 data AppInput = AIBundle !FilePath !EpochTime
@@ -407,7 +417,7 @@ data RestartCount = UnlimitedRestarts | LimitedRestarts !Word
 
 instance FromJSON RestartCount where
     parseJSON (String "unlimited") = return UnlimitedRestarts
-    parseJSON v = fmap LimitedRestarts $ parseJSON v
+    parseJSON v = LimitedRestarts <$> parseJSON v
 
 instance ParseYamlFile BackgroundConfig where
     parseYamlFile basedir = withObject "BackgroundConfig" $ \o -> BackgroundConfig

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -24,14 +24,13 @@ import           Data.Vector                       (Vector)
 import qualified Data.Vector                       as V
 import           Data.Word                         (Word)
 import           Data.Yaml.FilePath
-import qualified Filesystem.Path.CurrentOS         as F
+import qualified System.FilePath                   as F
 import           Keter.Types.Common
 import           Keter.Types.Middleware
 import qualified Keter.Types.V04                   as V04
 import           Network.HTTP.ReverseProxy.Rewrite (ReverseProxyConfig)
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Handler.WarpTLS       as WarpTLS
-import           Prelude                           hiding (FilePath)
 import           System.Posix.Types                (EpochTime)
 
 data BundleConfig = BundleConfig
@@ -124,9 +123,9 @@ instance ToCurrent KeterConfig where
         getSSL (Just (V04.TLSConfig s ts)) = V.singleton $ LPSecure
             (Warp.getHost s)
             (Warp.getPort s)
-            (F.decodeString $ WarpTLS.certFile ts)
+            (WarpTLS.certFile ts)
             V.empty
-            (F.decodeString $ WarpTLS.keyFile ts)
+            (WarpTLS.keyFile ts)
 
 instance Default KeterConfig where
     def = KeterConfig
@@ -253,7 +252,7 @@ instance ParseYamlFile StaticFilesConfig where
 
 instance ToJSON StaticFilesConfig where
     toJSON StaticFilesConfig {..} = object
-        [ "root" .= F.encodeString sfconfigRoot
+        [ "root" .= sfconfigRoot
         , "hosts" .= Set.map CI.original sfconfigHosts
         , "directory-listing" .= sfconfigListings
         , "middleware" .= sfconfigMiddleware
@@ -383,7 +382,7 @@ instance ParseYamlFile (WebAppConfig ()) where
 
 instance ToJSON (WebAppConfig ()) where
     toJSON WebAppConfig {..} = object
-        [ "exec" .= F.encodeString waconfigExec
+        [ "exec" .= waconfigExec
         , "args" .= waconfigArgs
         , "env" .= waconfigEnvironment
         , "hosts" .= map CI.original (waconfigApprootHost : Set.toList waconfigHosts)
@@ -420,7 +419,7 @@ instance ParseYamlFile BackgroundConfig where
 
 instance ToJSON BackgroundConfig where
     toJSON BackgroundConfig {..} = object $ catMaybes
-        [ Just $ "exec" .= F.encodeString bgconfigExec
+        [ Just $ "exec" .= bgconfigExec
         , Just $ "args" .= bgconfigArgs
         , Just $ "env" .= bgconfigEnvironment
         , case bgconfigRestartCount of

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,5 +1,5 @@
 Name:                keter
-Version:             1.3.10.1
+Version:             1.4.0
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/keter>.
 Homepage:            http://www.yesodweb.com/
@@ -35,13 +35,11 @@ Library
                      , yaml                      >= 0.8.4         && < 0.9
                      , unix-compat               >= 0.3           && < 0.5
                      , fsnotify                  >= 0.0.11
-                     , system-filepath           >= 0.4           && < 0.5
-                     , system-fileio             >= 0.3           && < 0.4
                      , conduit                   >= 1.1
                      , conduit-extra             >= 1.1
                      , http-reverse-proxy        >= 0.4           && < 0.5
                      , unix                      >= 2.5
-                     , wai-app-static            >= 3.0           && < 3.1
+                     , wai-app-static            >= 3.1           && < 3.2
                      , wai                       >= 3.0           && < 3.1
                      , wai-extra                 >= 3.0.3         && < 3.1
                      , http-types
@@ -87,7 +85,7 @@ Library
 Executable keter
   Main-is:             keter.hs
   hs-source-dirs:      main
-  Build-depends:       base, keter, system-filepath, data-default
+  Build-depends:       base, keter, data-default
   ghc-options:         -threaded -Wall
   other-modules:       Paths_keter
 

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,5 +1,5 @@
 Name:                keter
-Version:             1.4.0
+Version:             1.4.0.1
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/keter>.
 Homepage:            http://www.yesodweb.com/

--- a/keter.cabal
+++ b/keter.cabal
@@ -58,6 +58,7 @@ Library
                      , stm                       >= 2.4
                      , async
                      , lifted-base
+                     , system-filepath
   if impl(ghc < 7.6)
     build-depends:
                     ghc-prim
@@ -85,7 +86,7 @@ Library
 Executable keter
   Main-is:             keter.hs
   hs-source-dirs:      main
-  Build-depends:       base, keter, data-default
+  Build-depends:       base, keter, data-default, filepath
   ghc-options:         -threaded -Wall
   other-modules:       Paths_keter
 

--- a/main/keter.hs
+++ b/main/keter.hs
@@ -7,7 +7,7 @@ import Paths_keter (version)
 import Data.Version (showVersion)
 import qualified Keter.Plugin.Postgres as Postgres
 import Data.Default (def)
-import Filesystem.Path.CurrentOS ((</>), decodeString)
+import System.FilePath ((</>))
 
 main :: IO ()
 main = do
@@ -16,7 +16,7 @@ main = do
         ["--version"] -> putStrLn $ "keter version: " ++ showVersion version
         ["--help"] -> printUsage
         [dir] -> keter
-            (decodeString dir)
+            dir
             [\configDir -> Postgres.load def $ configDir </> "etc" </> "postgres.yaml"]
         _ -> printUsage
 


### PR DESCRIPTION
Add configurable time-outs.
 This allows to override time-outs for specific bundles.
 It uses modified `http-reverse-proxy` package. Where it moves handling time-outs there. Bonus is the web-socket handling is a bit better.
 Time-outs on static files will allow to 'stream' big files. 

Add `middleware` to `reverse-proxy` stanza
 This allows to add e.g `basic auth` to reversed hosts or maybe modify headers.