### PR TITLE
Appease redundant import warnings

### DIFF
--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -18,7 +18,7 @@ import           Control.Concurrent        (forkIO, threadDelay)
 import           Control.Concurrent.STM
 import           Control.Exception         (IOException, bracketOnError,
                                             throwIO, try)
-import           Control.Monad             (void, when, unless)
+import           Control.Monad             (void, when)
 import qualified Data.CaseInsensitive      as CI
 import           Data.Conduit.LogFile      (RotatingLog)
 import qualified Data.Conduit.LogFile      as LogFile

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -34,7 +34,7 @@ import qualified Network.HTTP.ReverseProxy.Rewrite as Rewrite
 import           Network.HTTP.Types                (mkStatus, status200,
                                                     status301, status302,
                                                     status303, status307,
-                                                    status404, status500)
+                                                    status404)
 import qualified Network.Wai                       as Wai
 import           Network.Wai.Application.Static    (defaultFileServerSettings,
                                                     ssListing, staticApp)
@@ -42,7 +42,6 @@ import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Handler.WarpTLS       as WarpTLS
 import           Network.Wai.Middleware.Gzip       (gzip)
 import           Prelude                           hiding (FilePath, (++))
-import           System.Timeout.Lifted             (timeout)
 import           WaiAppStatic.Listing              (defaultListing)
 
 -- | Mapping from virtual hostname to port number.


### PR DESCRIPTION
This PR is incomplete, because I think the warnings only apply to a particular version of GHC, and the changes may not be backward compatible. I'm on 7.8.4 and don't have a quick way to try earlier versions.