### PR TITLE
Add stack.yaml using LTS 2.11

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+flags:
+  keter: {}
+packages:
+- '.'
+extra-deps:
+- wai-app-static-3.1.0
+resolver: lts-2.11


### PR DESCRIPTION
Not sure 2.11 is appropriate, but pull-requesting for the fun of it. Note
the necessity of putting wai-app-static-3.1.0 as an extra-dep.