### PR TITLE
Remote postgres

### DIFF
--- a/Keter/Plugin/Postgres.hs
+++ b/Keter/Plugin/Postgres.hs
@@ -50,16 +50,16 @@ instance Default Settings where
                     "';\nCREATE DATABASE " <> fromText dbiName <>
                     " OWNER "              <> fromText dbiUser <>
                     ";"
-                cmd 
+                (cmd, args) 
                     | (  dbServer dbiServer == "localhost" 
                       || dbServer dbiServer == "127.0.0.1") = 
-                        [ "-u", "postgres", "psql" ]
+                        ("sudo", ["-u", "postgres", "psql"])
                     | otherwise = 
-                        [ "psql"
-                        , "-h", (T.unpack $ dbServer dbiServer)
+                        ("psql",
+                        [ "-h", (T.unpack $ dbServer dbiServer)
                         , "-p", (show $ dbPort dbiServer)
-                        , "-U", "postgres"]
-            _ <- readProcess "sudo" cmd $ TL.unpack sql
+                        , "-U", "postgres"])
+            _ <- readProcess cmd args $ TL.unpack sql
             return ()
         }
 

--- a/Keter/Plugin/Postgres.hs
+++ b/Keter/Plugin/Postgres.hs
@@ -50,10 +50,15 @@ instance Default Settings where
                     "';\nCREATE DATABASE " <> fromText dbiName <>
                     " OWNER "              <> fromText dbiUser <>
                     ";"
-                cmd = [ "-u", "postgres", "psql"
-                      , "-h", (T.unpack $ dbServer dbiServer)
-                      , "-p", (show $ dbPort dbiServer)
-                      , "-U", "postgres"] 
+                cmd 
+                    | (  dbServer dbiServer == "localhost" 
+                      || dbServer dbiServer == "127.0.0.1") = 
+                        [ "-u", "postgres", "psql" ]
+                    | otherwise = 
+                        [ "psql"
+                        , "-h", (T.unpack $ dbServer dbiServer)
+                        , "-p", (show $ dbPort dbiServer)
+                        , "-U", "postgres"]
             _ <- readProcess "sudo" cmd $ TL.unpack sql
             return ()
         }

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ plugins:
 ```
 
 Different webapps can be configured to use different servers using the above syntax.
+It should be noted that keter will prioritize it's own postgres.yaml record for an app. 
+So if moving an existing app from a local postgres server to a remote one (or 
+switching remote servers), the postgres.yaml file will need to be updated manually. 
+
 Keter will connect to the remote servers using the `postgres` account. This setup 
 assumes the remote server's `pg_hba.conf` file has been configured to allow connections
 from the keter-server IP using the `trust` method. 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,22 @@ plugins:
   postgres: true
 ```
 
+* Keter can be configured to connect to a remote postgres server using the following syntax:
+```yaml
+plugins:
+  postgres: 
+     - server: remoteServerNameOrIP
+       port: 1234
+```
+
+Different webapps can be configured to use different servers using the above syntax.
+Keter will connect to the remote servers using the `postgres` account. This setup 
+assumes the remote server's `pg_hba.conf` file has been configured to allow connections
+from the keter-server IP using the `trust` method. 
+
 (Note: The `plugins` configuration option was added in v1.0 of the
-keter configuration syntax. If you are using v0.4 then use `postgres: true`.)
+keter configuration syntax. If you are using v0.4 then use `postgres: true`.
+The remote-postgres server syntax was added in v1.4.2.)
 
 * Modify your application to get its database connection settings from the following environment variables:
     * `PGHOST`

--- a/incoming/foo1_0/config/keter.yaml
+++ b/incoming/foo1_0/config/keter.yaml
@@ -67,3 +67,7 @@ stanzas:
 
 plugins:
     #postgres: true
+# Syntax for remote-DB server:    
+#    postgres: 
+#       - server: remoteServerNameOrIP
+#         port: 1234

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,5 +1,5 @@
 Name:                keter
-Version:             1.4.1
+Version:             1.4.2
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/keter>.
 Homepage:            http://www.yesodweb.com/


### PR DESCRIPTION
#100 

Keter can manage a remote DB server, based on app settings. I believe it should be backwards compatible with existing postgres.yaml files, so I think only a minor version bump is necessary. 

This doesn't deal with the issue @ygale raised; it actually compounds the issue, as now there are more assumptions about postgres's setup. There are a few issues which might need to be decided before this is merged:
* The assumptions regarding how the remote DB server has been setup; specifically, the `trust` method note. Is it worth taking the time to try to allow for a username / password to be set in the app's settings? As a general rule, I don't like requiring plain-text passwords. 
* As I noted in the readme, if an app is changed to use a different server, but said app already exists in the postgres.yaml, keter will prioritize the old settings and ignore the new. (This is related to another issue which I've been thinking about - allowing for the postgres.yaml info to be updated without restarting keter). 