### PR TITLE
Change default connection time bound calculation from 5s to 5min.

### DIFF
--- a/Keter/Main.hs
+++ b/Keter/Main.hs
@@ -193,7 +193,9 @@ startListening KeterConfig {..} hostman = do
     manager <- HTTP.newManager HTTP.conduitManagerSettings
     runAndBlock kconfigListeners $ Proxy.reverseProxy
         kconfigIpFromHeader
-        kconfigConnectionTimeBound
+        -- calculate the number of microseconds since the
+        -- configuration option is in milliseconds
+        (kconfigConnectionTimeBound * 1000)
         manager
         (HostMan.lookupAction hostman . CI.mk)
 

--- a/Keter/Types/V04.hs
+++ b/Keter/Types/V04.hs
@@ -80,6 +80,7 @@ data KeterConfig = KeterConfig
     , kconfigReverseProxy        :: Set ReverseProxyConfig
     , kconfigIpFromHeader        :: Bool
     , kconfigConnectionTimeBound :: Int
+    -- ^ Maximum request time in milliseconds per connection.
     }
 
 instance Default KeterConfig where
@@ -95,6 +96,8 @@ instance Default KeterConfig where
         , kconfigConnectionTimeBound = fiveMinutes
         }
 
+
+-- | Default connection time bound in milliseconds.
 fiveMinutes :: Int
 fiveMinutes = 5 * 60 * 1000
 

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -102,6 +102,7 @@ data KeterConfig = KeterConfig
     , kconfigEnvironment         :: !(Map Text Text)
     -- ^ Environment variables to be passed to all apps.
     , kconfigConnectionTimeBound :: !Int
+    -- ^ Maximum request time in milliseconds per connection.
     }
 
 instance ToCurrent KeterConfig where


### PR DESCRIPTION
@geraldus 
@tolysz 

I believe there was a small issue with the 5 minute calculation, I couldn't find anywhere that explicitly states that the value is in microseconds but after some discussion on IRC and further testing I believe this is correct.