### PR TITLE
Env options for background tasks

### DIFF
--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -345,13 +345,6 @@ withBackgroundApps asc aid bconfig mdir rlog configs f =
   where
     alloc = launchBackgroundApp asc aid bconfig mdir rlog
 
-getForwardedEnv :: Set Text -> IO (Map Text Text)
-getForwardedEnv vars = filterEnv <$> getEnvironment
-  where
-    filterEnv = Map.filterWithKey (\k _ -> Set.member k vars)
-              . Map.fromList
-              . map (pack *** pack)
-
 launchBackgroundApp :: AppStartConfig
                     -> AppId
                     -> BundleConfig
@@ -605,6 +598,16 @@ getTimestamp = readTVar . appModTime
 
 pluginsGetEnv :: Plugins -> Appname -> Object -> IO [(Text, Text)]
 pluginsGetEnv ps app o = fmap concat $ mapM (\p -> pluginGetEnv p app o) ps
+
+-- | For the forward-env option. From a Set of desired variables, create a
+-- Map pulled from the system environment.
+getForwardedEnv :: Set Text -> IO (Map Text Text)
+getForwardedEnv vars = filterEnv <$> getEnvironment
+  where
+    filterEnv = Map.filterWithKey (\k _ -> Set.member k vars)
+              . Map.fromList
+              . map (pack *** pack)
+
 
     {- FIXME handle static stanzas
     let staticReverse r = do

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -409,6 +409,7 @@ data BackgroundConfig = BackgroundConfig
     , bgconfigEnvironment         :: !(Map Text Text)
     , bgconfigRestartCount        :: !RestartCount
     , bgconfigRestartDelaySeconds :: !Word
+    , bgconfigForwardEnv          :: !(Set Text)
     }
     deriving Show
 
@@ -426,6 +427,7 @@ instance ParseYamlFile BackgroundConfig where
         <*> o .:? "env" .!= Map.empty
         <*> o .:? "restart-count" .!= UnlimitedRestarts
         <*> o .:? "restart-delay-seconds" .!= 5
+        <*> o .:? "forward-env" .!= Set.empty
 
 instance ToJSON BackgroundConfig where
     toJSON BackgroundConfig {..} = object $ catMaybes
@@ -436,4 +438,5 @@ instance ToJSON BackgroundConfig where
             UnlimitedRestarts -> Nothing
             LimitedRestarts count -> Just $ "restart-count" .= count
         , Just $ "restart-delay-seconds" .= bgconfigRestartDelaySeconds
+        , Just $ "forward-env" .= bgconfigForwardEnv
         ]

--- a/incoming/foo1_0/config/keter.yaml
+++ b/incoming/foo1_0/config/keter.yaml
@@ -20,6 +20,8 @@ stanzas:
         - Keter Background Worker
       env:
         FROM_KETER_CONFIG: foo bar baz
+      forward-env:
+        - ENV_VAR_FOR_BACKGROUND
       restart-count: 10
       restart-delay-seconds: 6
 


### PR DESCRIPTION
Give background tasks a forward-env option, and also pass through the
environment variables specified in the keter config.