### PR TITLE
Use newer fsnotify to avoid system-filepath

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -34,7 +34,7 @@ Library
                      , blaze-builder             >= 0.3           && < 0.5
                      , yaml                      >= 0.8.4         && < 0.9
                      , unix-compat               >= 0.3           && < 0.5
-                     , fsnotify                  >= 0.0.11
+                     , fsnotify                  >= 0.2.0.2
                      , conduit                   >= 1.1
                      , conduit-extra             >= 1.1
                      , http-reverse-proxy        >= 0.4.2         && < 0.5


### PR DESCRIPTION
Newer versions of fsnotify avoid the need for encodeString. Prior to this change, I couldn't get keter to build on FreeBSD with ghc 7.10.1