### PR TITLE
Add filesystem-path compatibility for older fsnotify versions.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.3.1
+
+* Add cabal flag `system-filepath` for compatibility with older versions of fsnotify.
+
 ## 1.4.3
 
 * Update fsnotify dependency version and remove system-filepath.

--- a/Keter/Main.hs
+++ b/Keter/Main.hs
@@ -50,7 +50,7 @@ import qualified System.FSNotify           as FSN
 import           System.Posix.User         (getUserEntryForID,
                                             getUserEntryForName, userGroupID,
                                             userID, userName)
-#if !MIN_VERSION_fsnotify(0,2,0)
+#ifdef SYSTEM_FILEPATH
 import qualified Filesystem.Path as FP (FilePath)
 import           Filesystem.Path.CurrentOS (encodeString)
 #endif

--- a/keter.cabal
+++ b/keter.cabal
@@ -34,7 +34,6 @@ Library
                      , blaze-builder             >= 0.3           && < 0.5
                      , yaml                      >= 0.8.4         && < 0.9
                      , unix-compat               >= 0.3           && < 0.5
-                     , fsnotify                  >= 0.2.0.2
                      , conduit                   >= 1.1
                      , conduit-extra             >= 1.1
                      , http-reverse-proxy        >= 0.4.2         && < 0.5
@@ -58,6 +57,8 @@ Library
                      , stm                       >= 2.4
                      , async
                      , lifted-base
+                     , fsnotify >= 0.0.11
+                     , system-filepath
   if impl(ghc < 7.6)
     build-depends:
                     ghc-prim

--- a/keter.cabal
+++ b/keter.cabal
@@ -15,6 +15,10 @@ extra-source-files:  ChangeLog.md
 
 --Data-Files:        incoming/foo/bundle.sh, incoming/foo/config/keter.yaml
 
+flag system-filepath
+  description: Use system-filepath
+  default: False
+
 Library
   Build-depends:       base                      >= 4             && < 5
                      , directory
@@ -57,11 +61,16 @@ Library
                      , stm                       >= 2.4
                      , async
                      , lifted-base
-                     , fsnotify >= 0.0.11
-                     , system-filepath
+
   if impl(ghc < 7.6)
-    build-depends:
-                    ghc-prim
+    build-depends:     ghc-prim
+  if flag(system-filepath)
+    build-depends:     fsnotify >= 0.1 && < 0.2
+                     , system-filepath
+    cpp-options:       -DSYSTEM_FILEPATH
+  else
+    build-depends:     fsnotify >= 0.2.0.2
+
   Exposed-Modules:     Keter.Plugin.Postgres
                        Keter.Types
                        Keter.Types.V04

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,5 +1,5 @@
 Name:                keter
-Version:             1.4.3
+Version:             1.4.3.1
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/keter>.
 Homepage:            http://www.yesodweb.com/


### PR DESCRIPTION
@snoyberg I tested against lts-2.1. lts-2.2 still has issues with http-reverse-proxy.