### PR TITLE
Add stack support

### DIFF
--- a/packaging/mkketerdeb.sh
+++ b/packaging/mkketerdeb.sh
@@ -3,6 +3,8 @@ NAME=keter
 VER=1.3.6
 export PATH=$PATH:/var/lib/gems/1.8/bin
 FPM=$(which fpm)
+STACK=$(which stack)
+CABAL=$(which cabal)
 
 set -e
 
@@ -13,23 +15,49 @@ if [[ -z "$FPM" ]]; then
     FPM=$(which fpm)
 fi
 
-# ensure keter is there, otherwise install.
-if [[ ! -f .cabal-sandbox/bin/$NAME ]]; then
-    cabal sandbox init
-    cabal update
-    cabal install ..
+# Build project
+# Make sure either stack or cabal is present.
+if [[ ! -x "$STACK" ]]; then
+    if [[ ! -x "$CABAL" ]]; then
+        echo "Error: You need either cabal or stack"
+        exit
+    else
+        if [[ ! -f $($CABAL exec which $NAME) ]]; then
+            echo Building using cabal sandboxes...
+            $CABAL sandbox init
+            $CABAL update
+            $CABAL install ..
+            echo done
+        fi
+    fi
+else
+    if [[ ! -f $($STACK exec which $NAME) ]]; then
+        echo Building using stack...
+        $STACK build
+        echo done
+    fi
 fi
 
 # make folder structure
+echo copying files
 mkdir -p $NAME-$VER/{bin,etc,init/sysv,init/upstart,var/run/keter}
 mkdir -p $NAME-$VER/var/www/keter/{incoming,log,temp}
 
-# copy the keter bin into /bin
-cp .cabal-sandbox/bin/$NAME $NAME-$VER/bin/
+# copy the keter binary into /bin
+if [[ -f $($STACK exec which $NAME) ]]; then
+    cp $($STACK exec which $NAME) $NAME-$VER/bin/
+else
+    if [[ -f $($CABAL exec which $NAME) ]]; then
+        cp $($CABAL exec which $NAME) $NAME-$VER/bin/
+    else
+        echo Error: Something went wrong. Could not find the built executable.
+        exit
+    fi
+fi
 
 cd $NAME-$VER
 # copy over scripts if missing
-if [[ ! -f etc/keter-config.yaml ]]; then 
+if [[ ! -f etc/keter-config.yaml ]]; then
     cp ../etc/keter-config.yaml etc/keter-config.yaml
 fi
 if [[ ! -f init/sysv/keter ]]; then
@@ -40,7 +68,7 @@ if [[ ! -f init/upstart/keter ]]; then
 fi
 
 # use fpm to generate the debian package.
-
+echo building deb file
 # for sysv (debian 6,7)
 $FPM -n $NAME -v $VER -t deb --deb-init=init/sysv/keter \
                              --config-files /etc/keter.conf \
@@ -50,3 +78,4 @@ $FPM -n $NAME -v $VER -t deb --deb-init=init/sysv/keter \
 
 # for upstart (ubuntu?)
 # $FPM -n $NAME -v $VER -t deb --deb-init=init/sysv/keter --config-files /opt/keter/etc/keter-config.yaml -s dir bin/keter=/opt/keter/bin/keter etc/keter-config.yaml=/opt/keter/etc/keter-config.yaml
+echo DONE!

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,5 @@ flags:
   keter: {}
 packages:
 - '.'
-extra-deps:
-- wai-app-static-3.1.0
-resolver: lts-2.11
+extra-deps: []
+resolver: lts-3.5


### PR DESCRIPTION
This PR provides support for building a keter deb package using either stack or cabal. It also updates stack.yaml to use the latest LTS version.
