### PR TITLE
Allow manually specified approot.

### DIFF
--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -282,8 +282,11 @@ launchWebApp AppStartConfig {..} aid BundleConfig {..} mdir rlog WebAppConfig {.
             , Map.fromList otherEnv
             , kconfigEnvironment ascKeterConfig
             , Map.singleton "PORT" $ pack $ show waconfigPort
-            , Map.singleton "APPROOT" $ scheme <> CI.original waconfigApprootHost <> pack extport
+            , Map.singleton "APPROOT" . fromMaybe computedApproot $
+                                                  waconfigApproot
             ]
+        computedApproot =
+          scheme <> CI.original waconfigApprootHost <> pack extport
     exec <- canonicalizePath waconfigExec
     bracketOnError
         (monitorProcess

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -345,6 +345,7 @@ data WebAppConfig port = WebAppConfig
     { waconfigExec        :: !F.FilePath
     , waconfigArgs        :: !(Vector Text)
     , waconfigEnvironment :: !(Map Text Text)
+    , waconfigApproot     :: !(Maybe Text) -- ^ manually set approot
     , waconfigApprootHost :: !Host -- ^ primary host, used for approot
     , waconfigHosts       :: !(Set Host) -- ^ all hosts, not including the approot host
     , waconfigSsl         :: !Bool
@@ -360,6 +361,7 @@ instance ToCurrent (WebAppConfig ()) where
         { waconfigExec = exec
         , waconfigArgs = V.fromList args
         , waconfigEnvironment = Map.empty
+        , waconfigApproot = Nothing
         , waconfigApprootHost = CI.mk host
         , waconfigHosts = Set.map CI.mk hosts
         , waconfigSsl = ssl
@@ -383,6 +385,7 @@ instance ParseYamlFile (WebAppConfig ()) where
             <$> lookupBase basedir o "exec"
             <*> o .:? "args" .!= V.empty
             <*> o .:? "env" .!= Map.empty
+            <*> o .:? "approot"
             <*> return ahost
             <*> return hosts
             <*> o .:? "ssl" .!= False


### PR DESCRIPTION
For web apps, keter sets the `APPROOT` environment variable to inform the app, which sits behind keter's reverse proxying, of the correct approot as seen from the outside.

However, keter's algorithm to determine the approot is currently rather simplistic.

For example, keter always uses the first entry from the `hosts` list in the app bundle's keter.yaml, even if this particular request came in on a different hostname.

For the URL method - HTTP or HTTPS - keter inserts the method of the request as received. That is not always correct; for example, when SSL processing is delegated to an upstream router.

See also [this yesodweb thread](https://groups.google.com/forum/#!topic/yesodweb/SB-dcnaFXOs).

This PR provides a quick-and-dirty workaround for these problems. It allows you to override keter's approot algorithm completely by hard-coding the approot in the app bundle's keter.yaml file. A new parameter `approot` is now supported in webapp stanzas.

In the future, it would nice to expand this feature to give fine-grained control over the approot algorithm - to specify each of method, domain, and port separately as either a hard-coded value or taken from the request. That is compatible with this PR - specify `approot` as an object with fields instead of a single string value.

It also would be a good idea to improve keter's default approot algorithm. That is outside the scope of this PR.
