### PR TITLE
Initial implementation of SNI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - travis_retry sudo apt-get install --force-yes -y cabal-install-$CABALVER ghc-$GHCVER
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
  - cabal --version
 

--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -28,7 +28,7 @@ import           Data.Conduit.Process.Unix (MonitoredProcess, ProcessTracker,
 import           Data.IORef
 import qualified Data.Map                  as Map
 import           Data.Maybe                (fromMaybe)
-import           Data.Monoid               ((<>))
+import           Data.Monoid               ((<>), mempty)
 import qualified Data.Set                  as Set
 import           Data.Text                 (pack, unpack)
 import           Data.Text.Encoding        (decodeUtf8With, encodeUtf8)

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -9,7 +9,7 @@ module Keter.Proxy
     ) where
 
 import           Blaze.ByteString.Builder          (copyByteString)
-import           Control.Applicative               ((<|>))
+import           Control.Applicative               ((<$>), (<|>))
 import           Control.Monad.IO.Class            (liftIO)
 import qualified Data.ByteString                   as S
 import qualified Data.ByteString.Char8             as S8

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -43,9 +43,10 @@ import qualified Network.Wai.Handler.WarpTLS       as WarpTLS
 import           Network.Wai.Middleware.Gzip       (gzip)
 import           Prelude                           hiding (FilePath, (++))
 import           WaiAppStatic.Listing              (defaultListing)
+import qualified Network.TLS as TLS
 
 -- | Mapping from virtual hostname to port number.
-type HostLookup = ByteString -> IO (Maybe ProxyAction)
+type HostLookup = ByteString -> IO (Maybe (ProxyAction, TLS.Credentials))
 
 reverseProxy :: Bool
              -> Int -> Manager -> HostLookup -> ListeningPort -> IO ()
@@ -57,11 +58,23 @@ reverseProxy useHeader timeBound manager hostLookup listener =
         case listener of
             LPInsecure host port -> (Warp.runSettings (warp host port), False)
             LPSecure host port cert chainCerts key -> (WarpTLS.runTLS
-                (WarpTLS.tlsSettingsChain
+                (connectClientCertificates hostLookup $ WarpTLS.tlsSettingsChain
                     cert
                     (V.toList chainCerts)
                     key)
                 (warp host port), True)
+
+connectClientCertificates :: HostLookup -> WarpTLS.TLSSettings -> WarpTLS.TLSSettings
+connectClientCertificates hl s =
+    let
+        newHooks@TLS.ServerHooks{..} = WarpTLS.tlsServerHooks s
+        -- todo: add nested lookup
+        newOnServerNameIndication (Just n) =
+             maybe mempty snd <$> hl (S8.pack n)
+        newOnServerNameIndication Nothing =
+             return mempty -- we could return default certificate here
+    in
+        s { WarpTLS.tlsServerHooks = newHooks{TLS.onServerNameIndication = newOnServerNameIndication}}
 
 withClient :: Bool -- ^ is secure?
            -> Bool -- ^ use incoming request header for IP address
@@ -120,7 +133,7 @@ withClient isSecure useHeader bound manager hostLookup =
                         else hostLookup host'
         case mport of
             Nothing -> return (def, WPRResponse $ unknownHostResponse host)
-            Just (action, requiresSecure)
+            Just ((action, requiresSecure), _)
                 | requiresSecure && not isSecure -> performHttpsRedirect host req
                 | otherwise -> performAction req action
 

--- a/Keter/Types.hs
+++ b/Keter/Types.hs
@@ -22,5 +22,6 @@ import Keter.Types.V10 as X
     , BackgroundConfig (..)
     , RestartCount (..)
     , RequiresSecure
+    , SSLConfig (..)
     )
 import Network.HTTP.ReverseProxy.Rewrite as X (ReverseProxyConfig (..), RewriteRule (..))

--- a/incoming/foo1_0/config/keter.yaml
+++ b/incoming/foo1_0/config/keter.yaml
@@ -4,6 +4,13 @@ stanzas:
       args:
         - Hello World v1.0
       #ssl : true
+#      ssl:
+#        key: /opt/keter/etc/cert/hello.key
+#        certificate: /opt/keter/etc/cert/hello.crt
+#        chain-certificates:
+#          - /opt/keter/etc/middle.crt
+#          - /opt/keter/etc/root.crt
+
       env:
         FROM_KETER_CONFIG: foo bar baz
       forward-env:

--- a/keter.cabal
+++ b/keter.cabal
@@ -61,7 +61,7 @@ Library
                      , stm                       >= 2.4
                      , async
                      , lifted-base
-                     , tls
+                     , tls                       >= 1.3.4
 
   if impl(ghc < 7.6)
     build-depends:     ghc-prim

--- a/keter.cabal
+++ b/keter.cabal
@@ -61,6 +61,7 @@ Library
                      , stm                       >= 2.4
                      , async
                      , lifted-base
+                     , tls
 
   if impl(ghc < 7.6)
     build-depends:     ghc-prim

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ flags:
 packages:
 - '.'
 extra-deps: []
-resolver: lts-3.5
+resolver: lts-5.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,23 @@ flags:
   keter: {}
 packages:
 - '.'
+- location:
+    git: https://github.com/tolysz/hs-tls.git
+    commit: 0e5ba492a686b9aed32abbd1437860dbca2ebf4a
+  subdirs:
+    - core
+- location:
+    git: https://github.com/yesodweb/wai.git
+    commit: 7eded0855ea50dda4f3944f3d7ececb384b7eda3
+  subdirs:
+    - warp-tls
+    - wai
+    - warp
+    - wai-app-static
+    - auto-update
+    - mime-types
+  extra-dep: true
+
 extra-deps: []
-resolver: lts-3.5
+allow-newer: true
+resolver: nightly-2016-05-19

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,23 +2,5 @@ flags:
   keter: {}
 packages:
 - '.'
-- location:
-    git: https://github.com/tolysz/hs-tls.git
-    commit: 0e5ba492a686b9aed32abbd1437860dbca2ebf4a
-  subdirs:
-    - core
-- location:
-    git: https://github.com/yesodweb/wai.git
-    commit: 7eded0855ea50dda4f3944f3d7ececb384b7eda3
-  subdirs:
-    - warp-tls
-    - wai
-    - warp
-    - wai-app-static
-    - auto-update
-    - mime-types
-  extra-dep: true
-
 extra-deps: []
-allow-newer: true
-resolver: nightly-2016-05-19
+resolver: lts-3.5


### PR DESCRIPTION
Keter is created for hosting multiple apps; but all certificates need to be bundled together as one.
This patch adds possibility to have a different certificate per webapp... extending other stanzas should be as easy as that one.
PR is complete, however if someone have time to extend it to other parts (i.e. not just webapps)
And allow loading certificates require absolute paths (I placed various todos so feel free to pick them up).