### PR TITLE
Support require-secure with remote SSL terminators

### DIFF
--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -41,6 +41,7 @@ import           Network.Wai.Application.Static    (defaultFileServerSettings,
 import qualified Network.Wai.Handler.Warp          as Warp
 import qualified Network.Wai.Handler.WarpTLS       as WarpTLS
 import           Network.Wai.Middleware.Gzip       (gzip, GzipSettings(..), GzipFiles(..))
+import           Network.Wai.Request               (appearsSecure)
 import           Prelude                           hiding (FilePath, (++))
 import           WaiAppStatic.Listing              (defaultListing)
 import qualified Network.TLS as TLS
@@ -134,7 +135,7 @@ withClient isSecure useHeader bound manager hostLookup =
         case mport of
             Nothing -> return (def, WPRResponse $ unknownHostResponse host)
             Just ((action, requiresSecure), _)
-                | requiresSecure && not isSecure -> performHttpsRedirect host req
+                | requiresSecure && not (isSecure || appearsSecure req) -> performHttpsRedirect host req
                 | otherwise -> performAction req action
 
     performHttpsRedirect host =


### PR DESCRIPTION
Previously require-secure would cause a redirect loop if run on an
app server behind an SSL-terminating reverse proxy, like an Amazon
ELB. That's because it ignored X-FORWARDED-PROTO and other headers
and just checked whether keter was being talked to over an encrypted
socket. This change uses WAI's "was this request made over a secure
connection?" logic as a supplement to the old way.