### PR TITLE
Update resolver from 7.19 to 7.24

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ flags:
 packages:
 - '.'
 extra-deps: []
-resolver: lts-7.19
+resolver: lts-7.24


### PR DESCRIPTION
Closes #167. `lts-7.24` contains version 0.2.1 of `fsnotify`, which has a small fix I added (see #167 for details). AFAIU stackage, this version increment does not have any breaking API changes.