### PR TITLE
Fix cassava doubledash

### DIFF
--- a/setup-keter.sh
+++ b/setup-keter.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 set -o errexit -o nounset -o xtrace
 
 # Quick start:

--- a/setup-keter.sh
+++ b/setup-keter.sh
@@ -2,17 +2,19 @@
 set -o errexit -o nounset -o xtrace
 
 # Quick start:
-# wget -O - https://raw.github.com/snoyberg/keter/master/setup-keter.sh | bash -ex
-
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 575159689BEFB442
-echo "deb http://download.fpcomplete.com/ubuntu \"$(lsb_release -sc)\" main"|sudo tee /etc/apt/sources.list.d/fpco.list
+# wget -O - https://raw.github.com/snoyberg/keter/master/setup-keter.sh | bash -x
 
 sudo apt-get update
-sudo apt-get -y install postgresql stack zlib1g-dev
+sudo apt-get -y install postgresql zlib1g-dev
+
+# We pass `-f` to always upgrade to the latest stack.
+# It also makes sure that the script doesn't fail when
+# run for the second time, when stack is already installed.
+wget -qO- https://get.haskellstack.org/ | sh -s - -f
 
 stack update
 stack setup
-stack install keter
+stack install keter --resolver lts-7.19
 
 sudo mkdir -p /opt/keter/bin
 sudo cp ~/.local/bin/keter /opt/keter/bin


### PR DESCRIPTION
When trying to install keter with `wget -O - https://raw.githubusercontent.com/snoyberg/keter/master/setup-keter.sh | bash` I got:

```
...
+ stack setup
Writing implicit global project config file to: /root/.stack/global-project/stack.yaml
Note: You can change the snapshot via the resolver field there.
Using latest snapshot resolver: lts-10.3
Downloaded lts-10.3 build plan.    
AesonException "Error in $.packages.cassava.constraints.flags['bytestring--lt-0_10_4']: Invalid flag name: \"bytestring--lt-0_10_4\""
```

That is this issue: https://github.com/haskell-hvr/cassava/pull/155

This PR fixes it by making the `setup-keter.sh` install script install the latest version of stack.

It also fixes the problem that the `stack install` used inside didn't specify the resolver, so it might use a newer ghc than keter is compatible with. In my case, it didn't build with ghc 8.2, failing with:

```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for keter-1.4.3.2:
    unix-compat-0.5.0.1 from stack configuration does not match >=0.3 && <0.5 (latest
                        matching version is 0.4.3.1)
needed since keter is a build target.
```

So I pass `--resolver` giving the same resolver as in `stack.yaml` in this git repo.