### PR TITLE
Bump version bounds

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -27,7 +27,7 @@ Library
                      , text
                      , containers
                      , transformers
-                     , process                   >= 1.4.3         && < 1.6.8
+                     , process                   >= 1.4.3         && < 1.7
                      , random
                      , data-default
                      , filepath
@@ -45,7 +45,7 @@ Library
                      , unix                      >= 2.5
                      , wai-app-static            >= 3.1           && < 3.2
                      , wai                       >= 3.2.2
-                     , wai-extra                 >= 3.0.3         && < 3.1
+                     , wai-extra                 >= 3.0.3         && < 3.2
                      , http-types
                      , regex-tdfa                >= 1.1
                      , attoparsec                >= 0.10


### PR DESCRIPTION
process 1.6.8 -> 1.7 (note that process uses 4, however the final
number seems to be ignored)

wai-extra 3.1 -> 3.2
Last time this happened was 6 years ago.