### PR TITLE
Add aditional log messages to keter reloading logic.

### DIFF
--- a/Keter/App.hs
+++ b/Keter/App.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 module Keter.App
     ( App
     , AppStartConfig (..)
@@ -62,6 +63,8 @@ data App = App
     , appAsc            :: !AppStartConfig
     , appRlog           :: !(TVar (Maybe RotatingLog))
     }
+instance Show App where
+  show App {appId, ..} = "App{appId=" <> show appId <> "}"
 
 data RunningWebApp = RunningWebApp
     { rwaProcess :: !MonitoredProcess

--- a/Keter/AppManager.hs
+++ b/Keter/AppManager.hs
@@ -215,9 +215,11 @@ launchWorker AppManager {..} appid tstate tmnext mcurrentApp0 action0 = void $ f
 
     processAction Nothing Terminate = return Nothing
     processAction (Just app) Terminate = do
+        log $ Terminating $ show app
         App.terminate app
         return Nothing
     processAction Nothing (Reload input) = do
+        log $ ReloadFrom Nothing $ show input
         eres <- E.try $ App.start appStartConfig appid input
         case eres of
             Left e -> do
@@ -225,6 +227,7 @@ launchWorker AppManager {..} appid tstate tmnext mcurrentApp0 action0 = void $ f
                 return Nothing
             Right app -> return $ Just app
     processAction (Just app) (Reload input) = do
+        log $ ReloadFrom (Just $ show app) (show input)
         eres <- E.try $ App.reload app input
         case eres of
             Left e -> do

--- a/Keter/Types/Common.hs
+++ b/Keter/Types/Common.hs
@@ -84,9 +84,13 @@ data LogMessage
     | DeactivatingApp AppId (Set Host)
     | ReactivatingApp AppId (Set Host) (Set Host)
     | WatchedFile Text FilePath
+    | ReloadFrom (Maybe String) String
+    | Terminating String
 
 instance Show LogMessage where
     show (ProcessCreated f) = "Created process: " ++ f
+    show (ReloadFrom app input) = "Reloading from: " ++ show app  ++ " to " ++ show input
+    show (Terminating app) = "Terminating " ++ show app
     show (InvalidBundle f e) = concat
         [ "Unable to parse bundle file '"
         , f

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -34,7 +34,7 @@ import           System.Posix.Types                (EpochTime)
 data BundleConfig = BundleConfig
     { bconfigStanzas :: !(Vector (Stanza ()))
     , bconfigPlugins :: !Object -- ^ settings used for plugins
-    }
+    } deriving Show
 
 instance ToCurrent BundleConfig where
     type Previous BundleConfig = V04.BundleConfig
@@ -166,6 +166,7 @@ instance ParseYamlFile KeterConfig where
 type RequiresSecure = Bool
 
 data Stanza port = Stanza (StanzaRaw port) RequiresSecure
+  deriving Show
 
 data StanzaRaw port
     = StanzaStaticFiles !StaticFilesConfig
@@ -412,6 +413,7 @@ instance ToJSON (WebAppConfig ()) where
 
 data AppInput = AIBundle !FilePath !EpochTime
               | AIData !BundleConfig
+              deriving Show
 
 data BackgroundConfig = BackgroundConfig
     { bgconfigExec                :: !F.FilePath


### PR DESCRIPTION
It took me the longest time to figure out why keter wasn't
reloading properly (It trashed the old app while an erronous new one
was attempted to be loaded),
only after adding log messages like these, I realized
keter was actually rebooted with systemd (reload from nothing).

This was my own fault, however I think adding these log messages
would help speed up future debug sessions for other users.
This also adds several show instances to basic types in support of
this logging.