### PR TITLE
Add configurable timeout for ensure alive

### DIFF
--- a/Keter/Types/Common.hs
+++ b/Keter/Types/Common.hs
@@ -155,6 +155,7 @@ data KeterException = CannotParsePostgres FilePath
                     | CannotReserveHosts !AppId !(Map Host AppId)
                     | FileNotExecutable !FilePath
                     | ExecutableNotFound !FilePath
+                    | EnsureAliveShouldBeBiggerThenZero { keterExceptionGot:: !Int }
     deriving (Show, Typeable)
 instance Exception KeterException
 

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -360,7 +360,11 @@ data WebAppConfig port = WebAppConfig
     , waconfigSsl         :: !SSLConfig
     , waconfigPort        :: !port
     , waconfigForwardEnv  :: !(Set Text)
+     -- | how long are connections supposed to last
     , waconfigTimeout     :: !(Maybe Int)
+     -- | how long in microseconds the app gets before we expect it to bind to
+     --   a port (default 90 seconds)
+    , waconfigEnsureAliveTimeout :: !(Maybe Int)
     }
     deriving Show
 
@@ -376,6 +380,7 @@ instance ToCurrent (WebAppConfig ()) where
         , waconfigPort = ()
         , waconfigForwardEnv = Set.empty
         , waconfigTimeout = Nothing
+        , waconfigEnsureAliveTimeout = Nothing
         }
 
 instance ParseYamlFile (WebAppConfig ()) where
@@ -399,6 +404,7 @@ instance ParseYamlFile (WebAppConfig ()) where
             <*> return ()
             <*> o .:? "forward-env" .!= Set.empty
             <*> o .:? "connection-time-bound"
+            <*> o .:? "ensure-alive-time-bound"
 
 instance ToJSON (WebAppConfig ()) where
     toJSON WebAppConfig {..} = object

--- a/incoming/Makefile
+++ b/incoming/Makefile
@@ -18,6 +18,7 @@ all: foo.keter foo1_0.keter websockets
 foo: foo.keter
 foo1_0: foo1_0.keter
 websockets: websockets.keter
+nc: nc.keter
 
 
 foo.keter: ./foo/*.hs ./foo/config/*.yaml
@@ -26,6 +27,8 @@ foo.keter: ./foo/*.hs ./foo/config/*.yaml
 	strip ./foo/hello
 	cd foo; tar czfv ../foo.keter *
 
+nc.keter:
+	cd nc; tar czfv ../nc.keter *
 
 foo1_0.keter: ./foo1_0/*.hs ./foo1_0/config/*.yaml
 	@echo "Build foo1_0"

--- a/incoming/nc/Readme.md
+++ b/incoming/nc/Readme.md
@@ -1,0 +1,5 @@
+Shows how to configure a flexible timeout in keter.
+
+if the flexible timeout is below 10 seconds in this example,
+keter will continously try rebooting it,
+because the sleep takes 10 seconds inside `nc.sh`.

--- a/incoming/nc/config/keter.yaml
+++ b/incoming/nc/config/keter.yaml
@@ -1,0 +1,6 @@
+stanzas:
+    - host: localhost
+      type: webapp
+      exec: ../nc.sh
+      # 15 secends in microseconds
+      ensure-alive-time-bound: 15000000

--- a/incoming/nc/nc.sh
+++ b/incoming/nc/nc.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xe
+
+/usr/bin/env sleep 10
+
+/usr/bin/env nc -l "$PORT"


### PR DESCRIPTION
This allows certain application to have a long boot cycle while the
old application is still running.
A specific use case for supercede for example is running migrations
before switching.

fixes: https://github.com/snoyberg/keter/issues/218

-- squash log

Add comment it's in microseconds

Fix import styling