### PR TITLE
Simplify V04.TLSConfig to be compatible with warp-tls update.

### DIFF
--- a/Keter/Types/V04.hs
+++ b/Keter/Types/V04.hs
@@ -115,7 +115,7 @@ instance ParseYamlFile KeterConfig where
         <*> o .:? "ip-from-header" .!= False
         <*> o .:? "connection-time-bound" .!= fiveMinutes
 
-data TLSConfig = TLSConfig !Warp.Settings !WarpTLS.TLSSettings
+data TLSConfig = TLSConfig !Warp.Settings !FilePath !FilePath (Maybe TLSSession.Config)
 
 instance ParseYamlFile TLSConfig where
     parseYamlFile basedir = withObject "TLSConfig" $ \o -> do
@@ -125,14 +125,10 @@ instance ParseYamlFile TLSConfig where
         port <- o .:? "port" .!= 443
         session <- bool Nothing (Just TLSSession.defaultConfig) <$> o .:? "session" .!= False
         return $! TLSConfig
-            ( Warp.setHost host
-            $ Warp.setPort port
-              Warp.defaultSettings)
-            WarpTLS.defaultTlsSettings
-                { WarpTLS.certFile = cert
-                , WarpTLS.keyFile = key
-                , WarpTLS.tlsSessionManagerConfig = session
-                }
+            (Warp.setHost host $ Warp.setPort port Warp.defaultSettings)
+            cert
+            key
+            session
 
 -- | Controls execution of the nginx thread. Follows the settings type pattern.
 -- See: <http://www.yesodweb.com/book/settings-types>.

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -121,13 +121,13 @@ instance ToCurrent KeterConfig where
         }
       where
         getSSL Nothing = V.empty
-        getSSL (Just (V04.TLSConfig s ts)) = V.singleton $ LPSecure
+        getSSL (Just (V04.TLSConfig s cert key session)) = V.singleton $ LPSecure
             (Warp.getHost s)
             (Warp.getPort s)
-            (WarpTLS.certFile ts)
+            cert
             V.empty
-            (WarpTLS.keyFile ts)
-            (isJust $ WarpTLS.tlsSessionManagerConfig ts)
+            key
+            (isJust session)
 
 instance Default KeterConfig where
     def = KeterConfig

--- a/keter.cabal
+++ b/keter.cabal
@@ -55,7 +55,7 @@ Library
                      , array
                      , mtl
                      , warp
-                     , warp-tls                  >= 3.0.3         && < 3.3.0
+                     , warp-tls                  >= 3.0.3         && < 3.4.0
                      , aeson
                      , unordered-containers
                      , vector
@@ -92,7 +92,7 @@ Library
                        Data.Conduit.Process.Unix
   ghc-options:         -Wall
   c-sources:           cbits/process-tracker.c
-  
+
 Executable keter
   Main-is:             keter.hs
   hs-source-dirs:      main


### PR DESCRIPTION
No need to construct full TLSSettings in V04 TLSConfig, only to later extract certKey, certFile and tlsSessionManagerConfig from there when converting to V10. Simply keep certKey, certFile and tlsSessionManagerConfig in TLSConfig. This will allow usage of warp-tls 3.3 in Keter which was restricted in #213. With this change we don't need yesodweb/wai#841.


