### PR TITLE
Attempt add github action.

### DIFF
--- a/.github/workflows/stack.yaml
+++ b/.github/workflows/stack.yaml
@@ -1,0 +1,47 @@
+name: Stack
+
+on:
+    pull_request:
+    push:
+      branches:
+      - master
+
+jobs:
+  build:
+    name: CI
+    runs-on: ${{ matrix.os }}
+    env:
+      STACK_ROOT: ${{ github.workspace }}/.stack
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        resolver: [nightly, lts-18, lts-17, lts-16]
+        # Bugs in GHC make it crash too often to be worth running
+        exclude:
+          - os: windows-latest
+            resolver: nightly
+          - os: windows-latest
+            resolver: lts-16
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.stack
+            ${{ github.workspace }}/.stack
+          key: ${{ runner.os }}-${{ matrix.resolver }}-haskell-${{ hashFiles('stack.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.resolver }}-haskell-
+
+      - name: Build and run tests
+        shell: bash
+        run: |
+            set -ex
+            curl -sSL https://get.haskellstack.org/ | sh -s - -f
+            stack test --fast --no-terminal --resolver=${{ matrix.resolver }}


### PR DESCRIPTION
Travis stopped building for some reason.
I asked around and it turns out it's not
secure and only for paying customers:
https://arstechnica.com/information-technology/2021/09/travis-ci-flaw-exposed-secrets-for-thousands-of-open-source-projects/