### PR TITLE
Add optional debug cli, add a lot more logging

### DIFF
--- a/.github/workflows/stack.yaml
+++ b/.github/workflows/stack.yaml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest,
           # windows-latest # TODO add windows support
         ]
-        resolver: [nightly, lts-18, lts-17, lts-16]
+        resolver: [nightly, lts-18, lts-17]
         # Bugs in GHC make it crash too often to be worth running
         exclude:
           - os: macos-latest # no Cocoa ?? https://github.com/snoyberg/keter/runs/4103876510?check_suite_focus=true

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 1.6
-
-
+* Make keter more chatty on boot.
+  This allows you to figure out in code where things go wrong.
+* Add debug CLI, allowing you to inspect keters' internal state.
 
 ## 1.5
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,11 @@
 ## 1.6
 * Make keter more chatty on boot.
   This allows you to figure out in code where things go wrong.
-* Add debug CLI, allowing you to inspect keters' internal state.
+* Add opt-in debug CLI, allowing you to inspect keters' internal state.
+  You can activate it by specifying a cli-port.
+* Emit which pid is being killed by keter.
+  This helps with process leakage issues,
+  for example if the user launches from a bash script without using `exec`.
 
 ## 1.5
 

--- a/Data/Conduit/Process/Unix.hs
+++ b/Data/Conduit/Process/Unix.hs
@@ -330,14 +330,14 @@ printStatus :: MonitoredProcess -> IO Text
 printStatus (MonitoredProcess mstatus) = do
   mStatus <- tryReadMVar mstatus
   case mStatus of
-    Nothing -> pure "no status set"
-    Just NeedsRestart -> pure "needs restart"
-    Just NoRestart -> pure "no restart"
+    Nothing -> pure "no status set process"
+    Just NeedsRestart -> pure "needs-restart process"
+    Just NoRestart -> pure "no-restart process"
     Just (Running running) -> do
       x <- getPid running
       case x of
-        Just y -> pure ("running" <> pack (show y))
-        Nothing -> pure "just closed"
+        Just y -> pure ("running process '" <> pack (show y) <> "'")
+        Nothing -> pure "just closed process"
 
 -- | Terminate the process and prevent it from being restarted.
 terminateMonitoredProcess :: MonitoredProcess -> IO ()

--- a/Keter/Cli.hs
+++ b/Keter/Cli.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Keter.Cli
+    ( launchCli
+    , CliStates(..)
+    ) where
+
+import Keter.Types.Common
+import Keter.AppManager
+import Control.Concurrent (forkFinally)
+import qualified Control.Exception as E
+import Control.Monad (unless, forever, void, when)
+import qualified Data.ByteString as S
+import Network.Socket
+import Network.Socket.ByteString (recv, sendAll)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Options.Applicative
+import Data.Foldable
+import GHC.Conc
+
+data Commands = CmdListRunningApps
+              | CmdExit
+
+data CliStates = MkCliStates
+  { csAppManager :: !AppManager
+  , csLog        :: !(LogMessage -> IO ())
+  , csPort       :: !Port
+  }
+
+launchCli :: CliStates -> IO ()
+launchCli states = void $ forkIO $ withSocketsDo $ do
+    addr <- resolve $ show $ csPort states
+    E.bracket (open addr) close $ \x -> do
+                                    csLog states $ BindCli addr
+                                    loop states x
+commandParser :: Parser Commands
+commandParser = hsubparser $
+  fold [
+  command "exit"
+    (info (pure CmdExit)
+      (progDesc "List all ports"))
+  ,
+  command "apps"
+      (info (pure CmdListRunningApps)
+        (progDesc "Exit the program"))
+  ]
+
+resolve :: ServiceName -> IO AddrInfo
+resolve port = do
+        let hints = defaultHints {
+                addrFlags = [AI_PASSIVE]
+              , addrSocketType = Stream
+              }
+        addr:_ <- getAddrInfo (Just hints) Nothing (Just port)
+        return addr
+
+open :: AddrInfo -> IO Socket
+open addr = do
+    sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+    setSocketOption sock ReuseAddr 1
+    -- If the prefork technique is not used,
+    -- set CloseOnExec for the security reasons.
+    withFdSocket sock $ setCloseOnExecIfNeeded
+    bind sock (addrAddress addr)
+    listen sock 10
+    return sock
+
+loop :: CliStates -> Socket -> IO b
+loop states sock = forever $ do
+    (conn, peer) <- accept sock
+    csLog states $ ReceivedCliConnection peer
+    void $ forkFinally (talk states conn) (\_ -> close conn)
+
+listRunningApps :: CliStates -> Socket -> IO ()
+listRunningApps states conn = do
+  txt <- atomically $ renderApps $ csAppManager states
+  sendAll conn $ T.encodeUtf8 txt <> "\n"
+
+talk :: CliStates -> Socket -> IO ()
+talk states conn = do
+    msg <- recv conn 1024
+    unless (S.null msg) $ do
+      case T.decodeUtf8' msg of
+        Left exception -> sendAll conn ("decode error: " <> T.encodeUtf8 (T.pack $ show exception))
+        Right txt -> do
+          let res = execParserPure defaultPrefs (info (commandParser <**> helper)
+                                                (fullDesc <> header "server repl" <> progDesc (
+                        "repl for inspecting program state. You can connect to a socket and ask predefined questions")) ) (T.unpack <$> T.words txt)
+          isLoop <- case res of
+            (Success (CmdListRunningApps)) -> True <$ listRunningApps states conn
+            (Success (CmdExit   )) -> False <$ sendAll conn "bye\n"
+            (CompletionInvoked x) -> True <$ sendAll conn "completion ignored \n"
+            Failure failure        ->
+              True <$ sendAll conn (T.encodeUtf8 (T.pack $ fst $ renderFailure failure "") <> "\n")
+          when isLoop $ talk states conn

--- a/Keter/Main.hs
+++ b/Keter/Main.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+
 module Keter.Main
     ( keter
     ) where
@@ -54,14 +55,24 @@ import           System.Posix.User         (getUserEntryForID,
 import qualified Filesystem.Path as FP (FilePath)
 import           Filesystem.Path.CurrentOS (encodeString)
 #endif
-
+import Keter.Cli
 
 keter :: FilePath -- ^ root directory or config file
       -> [FilePath -> IO Plugin]
       -> IO ()
 keter input mkPlugins = withManagers input mkPlugins $ \kc hostman appMan log -> do
+    log LaunchCli
+    forM (kconfigCliPort kc) $ \port ->
+      launchCli (MkCliStates
+                { csAppManager = appMan
+                , csLog        = log
+                , csPort       = port
+                })
+    log LaunchInitial
     launchInitial kc appMan
+    log StartWatching
     startWatching kc appMan log
+    log StartListening
     startListening kc hostman
 
 -- | Load up Keter config.

--- a/Keter/Types/Common.hs
+++ b/Keter/Types/Common.hs
@@ -155,7 +155,7 @@ instance Show LogMessage where
         , fp
         ]
     show LaunchInitial = "Launching initial"
-    show (KillingApp port txt) = "Killing " <> show port <> " - " <> unpack txt
+    show (KillingApp port txt) = "Killing " <> unpack txt <> " running on port: "  <> show port
     show LaunchCli     = "Launching cli"
     show StartWatching = "Started watching"
     show StartListening = "Started listening"

--- a/Keter/Types/Common.hs
+++ b/Keter/Types/Common.hs
@@ -93,6 +93,7 @@ data LogMessage
     | StartListening
     | BindCli AddrInfo
     | ReceivedCliConnection SockAddr
+    | KillingApp Port Text
 
 instance Show LogMessage where
     show (ProcessCreated f) = "Created process: " ++ f
@@ -154,6 +155,7 @@ instance Show LogMessage where
         , fp
         ]
     show LaunchInitial = "Launching initial"
+    show (KillingApp port txt) = "Killing " <> show port <> " - " <> unpack txt
     show LaunchCli     = "Launching cli"
     show StartWatching = "Started watching"
     show StartListening = "Started listening"

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -103,6 +103,8 @@ data KeterConfig = KeterConfig
     -- ^ Environment variables to be passed to all apps.
     , kconfigConnectionTimeBound :: !Int
     -- ^ Maximum request time in milliseconds per connection.
+    , kconfigCliPort             :: !(Maybe Port)
+    -- ^ Port for the cli to listen on
     }
 
 instance ToCurrent KeterConfig where
@@ -118,6 +120,7 @@ instance ToCurrent KeterConfig where
         , kconfigExternalHttpsPort = 443
         , kconfigEnvironment = Map.empty
         , kconfigConnectionTimeBound = connectionTimeBound
+        , kconfigCliPort             = Nothing
         }
       where
         getSSL Nothing = V.empty
@@ -141,6 +144,7 @@ instance Default KeterConfig where
         , kconfigExternalHttpsPort = 443
         , kconfigEnvironment = Map.empty
         , kconfigConnectionTimeBound = V04.fiveMinutes
+        , kconfigCliPort             = Nothing
         }
 
 instance ParseYamlFile KeterConfig where
@@ -161,6 +165,7 @@ instance ParseYamlFile KeterConfig where
             <*> o .:? "external-https-port" .!= 443
             <*> o .:? "env" .!= Map.empty
             <*> o .:? "connection-time-bound" .!= V04.fiveMinutes
+            <*> o .:? "cli-port"
 
 -- | Whether we should force redirect to HTTPS routes.
 type RequiresSecure = Bool

--- a/keter.cabal
+++ b/keter.cabal
@@ -65,6 +65,8 @@ Library
                      , lifted-base
                      , tls                       >= 1.4
                      , tls-session-manager
+                     , optparse-applicative
+                     , indexed-traversable
 
   if impl(ghc < 7.6)
     build-depends:     ghc-prim
@@ -82,6 +84,7 @@ Library
                        Keter.App
                        Keter.AppManager
                        Keter.LabelMap
+                       Keter.Cli
                        Keter.Main
                        Keter.PortPool
                        Keter.Proxy


### PR DESCRIPTION
* Make keter more chatty on boot.
  This allows you to figure out in code where things go wrong.
* Add opt-in debug CLI, allowing you to inspect keters' internal state.
  You can activate it by specifying a cli-port.
* Emit which pid is being killed by keter.
  This helps with process leakage issues,
  for example if the user launches from a bash script without using `exec`.
