### PR TITLE
Add config to replace welcome to keter screen with custom page 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,19 @@
+## 1.9
+
 ## 1.8
 
 + Add NixOS support
 + Describe debug port in readme.
 + Improve ensure alive error message due to 
   https://github.com/snoyberg/keter/issues/236
++ Add `missing-host-response-file` and `unknown-host-response-file`
+  to the global keter config, which replace the default responses.
++ All missing-host responses will now fill the requested host in the
+  `X-Forwarded-Host: HOSTNAME` header, where HOSTNAME is the requested host.
+  This is done because the default response fills in the hostname.
+  Now javascript could potentially fix that by making another request
+  to itself.
++ Document missing configuration options in `etc/keter-config.yaml`
 
 ## 1.7
 

--- a/Keter/Main.hs
+++ b/Keter/Main.hs
@@ -12,7 +12,6 @@ module Keter.Main
 import qualified Codec.Archive.TempTarball as TempFolder
 import           Control.Concurrent.Async  (waitAny, withAsync)
 import           Control.Monad             (unless)
-import qualified Data.CaseInsensitive      as CI
 import qualified Data.Conduit.LogFile      as LogFile
 import           Data.Monoid               (mempty)
 import           Data.String               (fromString)
@@ -39,8 +38,6 @@ import           Data.Text.Encoding        (encodeUtf8)
 import qualified Data.Text.Read
 import           Data.Time                 (getCurrentTime)
 import           Data.Yaml.FilePath
-import qualified Network.HTTP.Conduit      as HTTP (tlsManagerSettings,
-                                                    newManager)
 import           Prelude                   hiding (FilePath, log)
 import           System.Directory          (createDirectoryIfMissing,
                                             createDirectoryIfMissing,
@@ -62,7 +59,7 @@ keter :: FilePath -- ^ root directory or config file
       -> IO ()
 keter input mkPlugins = withManagers input mkPlugins $ \kc hostman appMan log -> do
     log LaunchCli
-    forM (kconfigCliPort kc) $ \port ->
+    void $ forM (kconfigCliPort kc) $ \port ->
       launchCli (MkCliStates
                 { csAppManager = appMan
                 , csLog        = log
@@ -164,7 +161,7 @@ isKeter :: FilePath -> Bool
 isKeter fp = takeExtension fp == ".keter"
 
 startWatching :: KeterConfig -> AppMan.AppManager -> (LogMessage -> IO ()) -> IO ()
-startWatching kc@KeterConfig {..} appMan log = do
+startWatching kc appMan log = do
     -- File system watching
     wm <- FSN.startManager
     _ <- FSN.watchTree wm (fromString incoming) (const True) $ \e -> do
@@ -222,11 +219,8 @@ listDirectoryTree fp = do
 
 startListening :: KeterConfig -> HostMan.HostManager -> IO ()
 startListening config hostman = do
-    manager <- HTTP.newManager HTTP.tlsManagerSettings
-    runAndBlock (kconfigListeners config) $ Proxy.reverseProxy
-        config
-        manager
-        (HostMan.lookupAction hostman . CI.mk)
+    settings <- Proxy.makeSettings config hostman
+    runAndBlock (kconfigListeners config) $ Proxy.reverseProxy settings
 
 runAndBlock :: NonEmptyVector a
             -> (a -> IO ())

--- a/Keter/Main.hs
+++ b/Keter/Main.hs
@@ -221,13 +221,10 @@ listDirectoryTree fp = do
            ) (filter (\x -> x /= "." && x /= "..") dir)
 
 startListening :: KeterConfig -> HostMan.HostManager -> IO ()
-startListening KeterConfig {..} hostman = do
+startListening config hostman = do
     manager <- HTTP.newManager HTTP.tlsManagerSettings
-    runAndBlock kconfigListeners $ Proxy.reverseProxy
-        kconfigIpFromHeader
-        -- calculate the number of microseconds since the
-        -- configuration option is in milliseconds
-        (kconfigConnectionTimeBound * 1000)
+    runAndBlock (kconfigListeners config) $ Proxy.reverseProxy
+        config
         manager
         (HostMan.lookupAction hostman . CI.mk)
 

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -167,8 +167,8 @@ withClient isSecure KeterConfig {..} manager hostLookup =
                         else hostLookup host'
         case mport of
             Nothing -> do
-              unkownBody <- case kconfigUnkownHostResponse  of
-                Nothing -> pure $ defaultUnkownHostBody host
+              unkownBody <- case kconfigUnknownHostResponse  of
+                Nothing -> pure $ defaultUnknownHostBody host
                 Just x -> S.readFile x
               return (defaultLocalWaiProxySettings, WPRResponse $ unknownHostResponse host unkownBody)
             Just ((action, requiresSecure), _)
@@ -255,8 +255,8 @@ missingHostResponse missingHost = Wai.responseBuilder
     [("Content-Type", "text/html; charset=utf-8")]
     $ copyByteString missingHost
 
-defaultUnkownHostBody :: ByteString -> ByteString
-defaultUnkownHostBody host =
+defaultUnknownHostBody :: ByteString -> ByteString
+defaultUnknownHostBody host =
   "<!DOCTYPE html>\n<html><head><title>Welcome to Keter</title></head><body><h1>Welcome to Keter</h1><p>The hostname you have provided, <code>"
   <> host <> "</code>, is not recognized.</p></body></html>"
 

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -88,10 +88,10 @@ makeSettings psConfig@KeterConfig {..} hostman = do
     psManager <- HTTP.newManager HTTP.tlsManagerSettings
     psMissingHost <- case kconfigMissingHostResponse of
       Nothing -> pure defaultMissingHostBody
-      Just x -> taggedReadFile "kconfigMissingHostResponse" x
+      Just x -> taggedReadFile "unknown-host-response-file" x
     psUnkownHost <- case kconfigUnknownHostResponse  of
                 Nothing -> pure defaultUnknownHostBody
-                Just x -> const <$> taggedReadFile "kconfigUnknownHostResponse" x
+                Just x -> const <$> taggedReadFile "missing-host-response-file" x
     pure $ MkProxySettings{..}
     where
         psHostLookup = HostMan.lookupAction hostman . CI.mk

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -106,7 +106,7 @@ data KeterConfig = KeterConfig
     , kconfigCliPort             :: !(Maybe Port)
     -- ^ Port for the cli to listen on
 
-    , kconfigUnkownHostResponse  :: !(Maybe F.FilePath)
+    , kconfigUnknownHostResponse  :: !(Maybe F.FilePath)
     , kconfigMissingHostResponse :: !(Maybe F.FilePath)
     }
 
@@ -124,7 +124,7 @@ instance ToCurrent KeterConfig where
         , kconfigEnvironment = Map.empty
         , kconfigConnectionTimeBound = connectionTimeBound
         , kconfigCliPort             = Nothing
-        , kconfigUnkownHostResponse  = Nothing
+        , kconfigUnknownHostResponse  = Nothing
         , kconfigMissingHostResponse = Nothing
         }
       where
@@ -150,7 +150,7 @@ instance Default KeterConfig where
         , kconfigEnvironment = Map.empty
         , kconfigConnectionTimeBound = V04.fiveMinutes
         , kconfigCliPort             = Nothing
-        , kconfigUnkownHostResponse  = Nothing
+        , kconfigUnknownHostResponse  = Nothing
         , kconfigMissingHostResponse = Nothing
         }
 
@@ -174,7 +174,7 @@ instance ParseYamlFile KeterConfig where
             <*> o .:? "connection-time-bound" .!= V04.fiveMinutes
             <*> o .:? "cli-port"
             <*> o .:? "missing-host-response-file"
-            <*> o .:? "unkown-host-response-file"
+            <*> o .:? "unknown-host-response-file"
 
 -- | Whether we should force redirect to HTTPS routes.
 type RequiresSecure = Bool

--- a/Keter/Types/V10.hs
+++ b/Keter/Types/V10.hs
@@ -105,6 +105,9 @@ data KeterConfig = KeterConfig
     -- ^ Maximum request time in milliseconds per connection.
     , kconfigCliPort             :: !(Maybe Port)
     -- ^ Port for the cli to listen on
+
+    , kconfigUnkownHostResponse  :: !(Maybe F.FilePath)
+    , kconfigMissingHostResponse :: !(Maybe F.FilePath)
     }
 
 instance ToCurrent KeterConfig where
@@ -121,6 +124,8 @@ instance ToCurrent KeterConfig where
         , kconfigEnvironment = Map.empty
         , kconfigConnectionTimeBound = connectionTimeBound
         , kconfigCliPort             = Nothing
+        , kconfigUnkownHostResponse  = Nothing
+        , kconfigMissingHostResponse = Nothing
         }
       where
         getSSL Nothing = V.empty
@@ -145,6 +150,8 @@ instance Default KeterConfig where
         , kconfigEnvironment = Map.empty
         , kconfigConnectionTimeBound = V04.fiveMinutes
         , kconfigCliPort             = Nothing
+        , kconfigUnkownHostResponse  = Nothing
+        , kconfigMissingHostResponse = Nothing
         }
 
 instance ParseYamlFile KeterConfig where
@@ -166,6 +173,8 @@ instance ParseYamlFile KeterConfig where
             <*> o .:? "env" .!= Map.empty
             <*> o .:? "connection-time-bound" .!= V04.fiveMinutes
             <*> o .:? "cli-port"
+            <*> o .:? "missing-host-response-file"
+            <*> o .:? "unkown-host-response-file"
 
 -- | Whether we should force redirect to HTTPS routes.
 type RequiresSecure = Bool

--- a/etc/keter-config.yaml
+++ b/etc/keter-config.yaml
@@ -37,3 +37,13 @@ listeners:
 # Connection time bound in milliseconds, set to 0 to have no time bound,
 # i.e. keep connections alive indefinitely. Default value is 5 minutes.
 # connection-time-bound: 300000
+
+# replace the default keter responses with your company branding
+# If a host is requested that doesn't exist next to other apps
+# this response is used
+# missing-host-response-file: ./missing-host.html
+# If no hosts at all are available this file is used
+# unknown-host-response-file: ./unkown-host.html
+
+# set a debug port
+# cli-port: 1234

--- a/etc/keter-config.yaml
+++ b/etc/keter-config.yaml
@@ -43,10 +43,10 @@ listeners:
 #
 # If a host is requested that doesn't exist next to other apps
 # this response is used
-missing-host-response-file: ./missing-host.html
+# missing-host-response-file: ./missing-host.html
 #
 # If no hosts at all are available this file is used
-unknown-host-response-file: ./unkown-host.html
+# unknown-host-response-file: ./unkown-host.html
 
 # set a debug port
 # cli-port: 1234

--- a/etc/keter-config.yaml
+++ b/etc/keter-config.yaml
@@ -39,11 +39,14 @@ listeners:
 # connection-time-bound: 300000
 
 # replace the default keter responses with your company branding
+# These could point the the same file, that's fine.
+#
 # If a host is requested that doesn't exist next to other apps
 # this response is used
-# missing-host-response-file: ./missing-host.html
+missing-host-response-file: ./missing-host.html
+#
 # If no hosts at all are available this file is used
-# unknown-host-response-file: ./unkown-host.html
+unknown-host-response-file: ./unkown-host.html
 
 # set a debug port
 # cli-port: 1234

--- a/incoming/Makefile
+++ b/incoming/Makefile
@@ -12,7 +12,7 @@ CABAL_ARGS = --sandbox-config-file=$(PKGCONF)
 
 
 all: foo.keter foo1_0.keter websockets
-.PHONY: all
+.PHONY: all nc.keter
 
 # Simple targets
 foo: foo.keter


### PR DESCRIPTION
+ [x] still need to test

I tested unkown host with:
```
nc localhost 8080
GET / HTTP/1.0

```
No host was added.
where blah wasn't a running host (only the nc example ran on localhost)

The other response we can get with:
```
nc localhost 8080
GET / HTTP/1.0
HOST: blah

```

The other one is quite easy by running keter with no hosts
(so just deleting all .keter files in incoming

+ [x] update changelog
+ [ ] make release

Implements: https://github.com/snoyberg/keter/issues/217