### PR TITLE
Fix potential xss issue in missing host response

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.8.2 
+
++ Fix XSS issue in the default response.
+  (special thanks to Max @ulidtko for spotting and fixing this)
+
 ## 1.8.1
 
 + Fix haddock build

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -13,7 +13,8 @@ module Keter.Proxy
 import qualified Network.HTTP.Conduit      as HTTP
 import qualified Data.CaseInsensitive      as CI
 import qualified Keter.HostManager         as HostMan
-import           Blaze.ByteString.Builder          (copyByteString)
+import           Blaze.ByteString.Builder          (copyByteString, toByteString)
+import           Blaze.ByteString.Builder.Html.Word(fromHtmlEscapedByteString)
 import           Control.Applicative               ((<$>), (<|>))
 import           Control.Monad.IO.Class            (liftIO)
 import qualified Data.ByteString                   as S
@@ -284,10 +285,13 @@ missingHostResponse missingHost = Wai.responseBuilder
 defaultUnknownHostBody :: ByteString -> ByteString
 defaultUnknownHostBody host =
   "<!DOCTYPE html>\n<html><head><title>Welcome to Keter</title></head><body><h1>Welcome to Keter</h1><p>The hostname you have provided, <code>"
-  <> host <> "</code>, is not recognized.</p></body></html>"
+  <> escapeHtml host <> "</code>, is not recognized.</p></body></html>"
 
 unknownHostResponse :: ByteString -> ByteString -> Wai.Response
 unknownHostResponse host body = Wai.responseBuilder
     status200
     [("Content-Type", "text/html; charset=utf-8"), ("X-Forwarded-Host", host)]
     (copyByteString body)
+
+escapeHtml :: ByteString -> ByteString
+escapeHtml = toByteString . fromHtmlEscapedByteString

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       >=1.10
 Name:                keter
-Version:             1.8.1
+Version:             1.8.2
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/keter>.
 Homepage:            http://www.yesodweb.com/


### PR DESCRIPTION
The host field can be spoofed,
which allows an xss attack.
Eg you can put a bunch of javascript
(or whatever html) in the hostfield and
response to trick the user.
These chagnes make that impossible.

add changelog, bump cabal