### PR TITLE
Escape X-Forwarded-Host header as well

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.8.3
+
++ HTML escape X-forwarded-host response as well.
+
 ## 1.8.2 
 
 + Fix XSS issue in the default response for host not found.

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -290,7 +290,12 @@ defaultUnknownHostBody host =
 unknownHostResponse :: ByteString -> ByteString -> Wai.Response
 unknownHostResponse host body = Wai.responseBuilder
     status200
-    [("Content-Type", "text/html; charset=utf-8"), ("X-Forwarded-Host", host)]
+    [("Content-Type", "text/html; charset=utf-8"),
+     ("X-Forwarded-Host",
+      -- if an attacker manages to insert line breaks somehow,
+      -- this is also vulnerable.
+      escapeHtml host
+     )]
     (copyByteString body)
 
 escapeHtml :: ByteString -> ByteString

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       >=1.10
 Name:                keter
-Version:             1.8.2
+Version:             1.8.3
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/keter>.
 Homepage:            http://www.yesodweb.com/


### PR DESCRIPTION
It seems unlikely an attacker will actually manage
to insert a line break at that point.
But since this isn't a common code path.
We may as well escape it for HTML.