### PR TITLE
Add proper status codes to error host responses

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.9
+
++ Update status code of missing host responses.
+  They now emit a 502 on missing host, and 404 on host not found
+
 ## 1.8.4
 
 + Get rid of ominious warning at the top.

--- a/Keter/Proxy.hs
+++ b/Keter/Proxy.hs
@@ -53,7 +53,7 @@ import qualified Network.HTTP.ReverseProxy.Rewrite as Rewrite
 import           Network.HTTP.Types                (mkStatus, status200,
                                                     status301, status302,
                                                     status303, status307,
-                                                    status404)
+                                                    status404, status502)
 import qualified Network.Wai                       as Wai
 import           Network.Wai.Application.Static    (defaultFileServerSettings,
                                                     ssListing, staticApp)
@@ -278,7 +278,7 @@ defaultMissingHostBody = "<!DOCTYPE html>\n<html><head><title>Welcome to Keter</
 
 missingHostResponse :: ByteString -> Wai.Response
 missingHostResponse missingHost = Wai.responseBuilder
-    status200
+    status502
     [("Content-Type", "text/html; charset=utf-8")]
     $ copyByteString missingHost
 
@@ -289,7 +289,7 @@ defaultUnknownHostBody host =
 
 unknownHostResponse :: ByteString -> ByteString -> Wai.Response
 unknownHostResponse host body = Wai.responseBuilder
-    status200
+    status404
     [("Content-Type", "text/html; charset=utf-8"),
      ("X-Forwarded-Host",
       -- if an attacker manages to insert line breaks somehow,

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       >=1.10
 Name:                keter
-Version:             1.8.4
+Version:             1.9
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:
     Deployment system for web applications, originally intended for hosting Yesod


### PR DESCRIPTION
We got a dedicated status code for this (502).
If a host is not found we now return 404.
Before this was 200 status codes (ok, which it's not)
pages even though hosts were missing!

This should make writing tests easier and make
monitoring systems more alert.

Update changelog

bump version