### PR TITLE
change nix config to always restart keter

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 + Update status code of missing host responses.
   They now emit a 502 on missing host, and 404 on host not found
++ Always restart keter in the nix config for systemd.
+  It turns out that keter may exit with exit code 0 under load testing.
+  Changing from on-failure to always in systemd should bring it back up.
 + Squash proxy exceptions if they occur and serve a default or custom error
   response.
   Emits the exception to the log.

--- a/nix/config.nix
+++ b/nix/config.nix
@@ -40,7 +40,10 @@ in {
     '';
     wantedBy = [ "multi-user.target" "nginx.service" ];
 
-    serviceConfig = { Restart = "on-failure"; };
+    serviceConfig = {
+      Restart="always";
+      RestartSec="10s";
+    };
 
     after = [
       "network.target"


### PR DESCRIPTION
under load this becomes an issue.
I'm unsure why it crashed, most likely systemd decided
to send it a sigterm signal.
This is the config nginx uses as well.