### PR TITLE
Better error messages for missing sudo when attempting psql connection

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.9.1
+
++ Improve missing sudo error messages in postgres plugin.
+
 ## 1.9
 
 + Update status code of missing host responses.

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       >=1.10
 Name:                keter
-Version:             1.9
+Version:             1.9.1
 Synopsis:            Web application deployment manager, focusing on Haskell web frameworks
 Description:
     Deployment system for web applications, originally intended for hosting Yesod


### PR DESCRIPTION
Closes #238. I ended up having to deal with other issues, which caused this to be delayed. 

The solution I choose was to  annotate the IOException with a better error message directly inside the postgres plugin. Since I am annotating the exception in the postgres plugin, when sudo is used in other places it won't use this message. 

Another possible solution is to create a custom KeterException for missing sudo, and then throw that when we get the missing sudo IOException. The advantage of that is that we can reuse the exception in all the places where we get an error because we are missing sudo, the downside is in adding more coding, and creating a custom KeterException when we don't necessarily need one.