### PR TITLE
Make `processMonitor` logging consistent with the rest of `keter` logs

### DIFF
--- a/src/Keter/App.hs
+++ b/src/Keter/App.hs
@@ -359,8 +359,7 @@ launchWebApp aid BundleConfig {..} mdir appLogger WebAppConfig {..} f = do
     exec <- liftIO $ canonicalizePath waconfigExec
     mainLogger <- askLoggerIO
     withRunInIO $ \rio -> bracketOnError
-        (monitorProcess
-            (Log.loggerLog appLogger . formatProcessMonitorLog (Log.loggerType appLogger) . toLogStr)
+        (rio $ monitorProcess
             ascProcessTracker
             (encodeUtf8 . fst <$> ascSetuid)
             (encodeUtf8 $ pack exec)
@@ -485,8 +484,7 @@ launchBackgroundApp aid BundleConfig {..} mdir appLogger BackgroundConfig {..} f
                     return res
     mainLogger <- askLoggerIO
     withRunInIO $ \rio -> bracketOnError
-        (monitorProcess
-            (Log.loggerLog appLogger . formatProcessMonitorLog (Log.loggerType appLogger) . toLogStr)
+        (rio $ monitorProcess
             ascProcessTracker
             (encodeUtf8 . fst <$> ascSetuid)
             (encodeUtf8 $ pack exec)

--- a/src/Keter/App.hs
+++ b/src/Keter/App.hs
@@ -314,20 +314,10 @@ withWebApps aid bconfig mdir appLogger configs0 f =
   where
     alloc = launchWebApp aid bconfig mdir appLogger
 
-formatTag :: FL.LogType
-          -> LogStr -- ^ tag
-          -> LogStr -- ^ message
-          -> LogStr
-formatTag (FL.LogStderr _) tag msg = tag <> "> " <> msg
-formatTag _ _ msg = msg
-
--- | Format a log message for the process monitor by tagging it with 'process-monitor>'
-formatProcessMonitorLog :: FL.LogType -> LogStr -> LogStr
-formatProcessMonitorLog lt = formatTag lt "process-monitor"
-
--- | Format a log message for an app by tagging it with 'app-$name>'
+-- | Format a log message for an app by tagging it with 'app-$name>' (only when it is being logged to stderr)
 formatAppLog :: AppId -> FL.LogType -> LogStr -> LogStr
-formatAppLog aid lt msg = formatTag lt (toLogStr (appLogName aid)) msg
+formatAppLog aid (FL.LogStderr _) msg = toLogStr (appLogName aid) <> "> " <> msg
+formatAppLog _ _ msg = msg
 
 launchWebApp :: AppId
              -> BundleConfig


### PR DESCRIPTION
This PR changes `processMonitor` to be defined in terms of some `MonadLogger m`, so we can use TH logging splices like every other module in keter and achieve consistent formatting via the main logger. 

Previously, there was a TODO comment above `processMonitor` suggesting it be refactored to use `KeterM`; however the `Keter.Conduit.Process.Unix` module could otherwise be packaged independently of `keter` in the future and I did not want to unnecessarily tightly couple it with the rest of `keter` as such. By defining it in terms of some polymorphic `MonadLogger m`, we can specialize `processMonitor` to `KeterM` to be used in the rest of `keter`, but still allow for flexibility to be specialized to other logging contexts should it ever be packaged independently in the future. 

With this refactor out of the way:
- All calls to `processMonitor` have been changed to drop the manual passing of the logger as a parameter. 
- `formatProcessMonitorLog` has been removed as the main keter logger takes care of log formatting for `processMonitor` now.
- `formatTag` has been combined into `formatAppLog` since `formatProcessMonitorLog` no longer exists to justify the separation of logic.