### PR TITLE
Add config "healthcheck-path" to respond 200 on

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 ## 2.1.3
 
+* Add `healthcheck-path` global config for Keter-only healthchecks. PR #283
+
 * Fix config keys `unknown-host-response-file` and `missing-host-response-file`
   accidentally flipped. PR #282
 * In case reading any one of `*-host-response-file` fails, keter now logs a warning,

--- a/etc/keter-config.yaml
+++ b/etc/keter-config.yaml
@@ -21,13 +21,14 @@ listeners:
       session: true
 
 # User to run applications as
-
 # setuid: ubuntu
 
 # Get the user's IP address from x-forwarded-for. Useful when sitting behind a
 # load balancer like Amazon ELB.
-
 # ip-from-header: true
+
+# If set, this path will respond 200 OK to requests on any vhost
+# healthcheck-path: /keter-health
 
 # Control the port numbers assigned via APPROOT
 # external-http-port: 8080

--- a/keter.cabal
+++ b/keter.cabal
@@ -114,6 +114,7 @@ library
     Keter.Yaml.FilePath
 
   other-modules:    Keter.Aeson.KeyHelper
+                    Paths_keter
   ghc-options:      -Wall
   c-sources:        cbits/process-tracker.c
   hs-source-dirs:   src

--- a/src/Keter/Config/V10.hs
+++ b/src/Keter/Config/V10.hs
@@ -114,6 +114,7 @@ data KeterConfig = KeterConfig
     , kconfigProxyException       :: !(Maybe F.FilePath)
 
     , kconfigRotateLogs           :: !Bool
+    , kconfigHealthcheckPath      :: !(Maybe Text)
     }
 
 instance ToCurrent KeterConfig where
@@ -134,6 +135,7 @@ instance ToCurrent KeterConfig where
         , kconfigMissingHostResponse = Nothing
         , kconfigProxyException = Nothing
         , kconfigRotateLogs = True
+        , kconfigHealthcheckPath = Nothing
         }
       where
         getSSL Nothing = V.empty
@@ -162,6 +164,7 @@ defaultKeterConfig = KeterConfig
         , kconfigMissingHostResponse = Nothing
         , kconfigProxyException = Nothing
         , kconfigRotateLogs = True
+        , kconfigHealthcheckPath = Nothing
         }
 
 instance ParseYamlFile KeterConfig where
@@ -187,6 +190,7 @@ instance ParseYamlFile KeterConfig where
             <*> o .:? "missing-host-response-file"
             <*> o .:? "proxy-exception-response-file"
             <*> o .:? "rotate-logs" .!= True
+            <*> o .:? "app-crash-hook"
 
 -- | Whether we should force redirect to HTTPS routes.
 type RequiresSecure = Bool
@@ -317,7 +321,7 @@ instance ToCurrent RedirectConfig where
 
 instance ParseYamlFile RedirectConfig where
     parseYamlFile _ = withObject "RedirectConfig" $ \o -> RedirectConfig
-        <$> (Set.map CI.mk <$> ((o .: "hosts" <|> (Set.singleton <$> (o .: "host")))))
+        <$> (Set.map CI.mk <$> (o .: "hosts" <|> Set.singleton <$> o .: "host"))
         <*> o .:? "status" .!= 303
         <*> o .: "actions"
         <*> o .:? "ssl" .!= SSLFalse

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -98,4 +98,5 @@ headThenPostNoCrash = do
       , psProxyException = ""
       , psIpFromHeader   = False
       , psConnectionTimeBound = 5 * 60 * 1000
+      , psHealthcheckPath = Nothing
       }


### PR DESCRIPTION
Hi again,

Here's another patch I'm trying to unvendor, as it seems universally useful to any user of keter.

The motivating problem is:
 * AWS LB TG healthcheck cannot currently be made to send any custom Host header. It always sends the target's (keter's) IP address in there, e.g. `Host: 172.30.131.18`.

Together with vhosting, this makes it impossible to healthcheck¹ individual webapps running under keter.

¹ *healthcheck from AWS TG* more specifically; still doable with other monitoring systems.

--------------------

Have a partial remedy with a `/keter-health` endpoint, that if enabled always responds with status 200.

For sake of explicitness, there's no hardcoded fallback for the path — if absent from config, the feature is disabled. If enabled in config, that same config explicitly spells out the HTTP request path.