### PR TITLE
Accommodate tls-2.1.0

### DIFF
--- a/src/Keter/Proxy.hs
+++ b/src/Keter/Proxy.hs
@@ -134,9 +134,9 @@ reverseProxy listener = do
   settings <- ask
   let (run, isSecure) =
           case listener of
-              LPInsecure host port -> 
+              LPInsecure host port ->
                   (liftIO . Warp.runSettings (warp host port), False)
-              LPSecure host port cert chainCerts key session -> 
+              LPSecure host port cert chainCerts key session ->
                   (liftIO . WarpTLS.runTLS
                       (connectClientCertificates (psHostLookup settings) session $ WarpTLS.tlsSettingsChain
                           cert
@@ -150,7 +150,7 @@ reverseProxy listener = do
 connectClientCertificates :: (ByteString -> IO (Maybe (ProxyAction, TLS.Credentials))) -> Bool -> WarpTLS.TLSSettings -> WarpTLS.TLSSettings
 connectClientCertificates hl session s =
     let
-        newHooks@TLS.ServerHooks{..} = WarpTLS.tlsServerHooks s
+        newHooks = WarpTLS.tlsServerHooks s
         -- todo: add nested lookup
         newOnServerNameIndication (Just n) =
              maybe mempty snd <$> hl (S8.pack n)
@@ -179,7 +179,7 @@ withClient isSecure = do
             } psManager
   where
     logException :: Wai.Request -> SomeException -> KeterM ProxySettings ()
-    logException a b = logErrorN $ pack $ 
+    logException a b = logErrorN $ pack $
       "Got a proxy exception on request " <> show a <> " with exception "  <> show b
 
 


### PR DESCRIPTION
See:
* https://github.com/commercialhaskell/stackage/issues/7464
* https://github.com/haskell-tls/hs-tls/issues/482

@jappeace, I can get this to build with a dependency on `tls-2.1.0` on Linux (via WSL2 on Windows 11) with `stack.yaml`:
~~~yaml
snapshot: nightly-2024-10-23 # GHC 9.8.2
extra-deps:
- tls-2.1.0

allow-newer: true
~~~

It seems that record syntax can be used to update a value even if the data constructor is not exported, as long as the field name is exported.