### PR TITLE
Remove CPP

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -23,10 +23,6 @@ extra-source-files:
   ChangeLog.md
   README.md
 
-flag system-filepath
-  description: Use system-filepath
-  default:     False
-
 library
   default-language:   Haskell98
   default-extensions: ImportQualifiedPost
@@ -56,7 +52,7 @@ library
     , mtl                   >=2.2.2    && <2.3     || ^>=2.3.1
     , network               >=3.1.2    && <3.2     || ^>=3.2.0
     , optparse-applicative  >=0.16.1   && <0.18    || ^>=0.18.1.0
-    , process               >=1.4.3    && <1.7
+    , process               >=1.6      && <1.7
     , random                >=1.2.1    && <1.3
     , regex-tdfa            >=1.3.1    && <1.4
     , stm                   >=2.5.0    && <2.6
@@ -82,10 +78,6 @@ library
 
   if impl(ghc <7.6)
     build-depends: ghc-prim
-
-  if flag(system-filepath)
-    build-depends: system-filepath
-    cpp-options:   -DSYSTEM_FILEPATH
 
   exposed-modules:
     Keter.App

--- a/src/Keter/Aeson/KeyHelper.hs
+++ b/src/Keter/Aeson/KeyHelper.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | Utilities for dealing with Aeson version update
+--
+-- TODO: This is no longer necessary, and should be removed.
 module Keter.Aeson.KeyHelper
   ( module KeyMap
   , toKey

--- a/src/Keter/Conduit/Process/Unix.hs
+++ b/src/Keter/Conduit/Process/Unix.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE LambdaCase #-}
@@ -98,13 +97,7 @@ import System.Process
 import System.Process.Internals (ProcessHandle(..), ProcessHandle__(..))
 
 processHandleMVar :: ProcessHandle -> MVar ProcessHandle__
-#if MIN_VERSION_process(1, 6, 0)
 processHandleMVar (ProcessHandle m _ _) = m
-#elif MIN_VERSION_process(1, 2, 0)
-processHandleMVar (ProcessHandle m _) = m
-#else
-processHandleMVar (ProcessHandle m) = m
-#endif
 
 withProcessHandle_ ::
      ProcessHandle
@@ -253,21 +246,13 @@ forkExecuteLog cmd args menv mwdir mstdin log = bracketOnError
             , std_err = UseHandle writerH
             , close_fds = True
             , create_group = True
-#if MIN_VERSION_process(1, 5, 0)
             , use_process_jobs = False
-#endif
-#if MIN_VERSION_process(1, 2, 0)
             , delegate_ctlc = False
-#endif
-#if MIN_VERSION_process(1, 3, 0)
             , detach_console = True
             , create_new_console = False
             , new_session = True
-#endif
-#if MIN_VERSION_process(1, 4, 0)
             , child_group = Nothing
             , child_user = Nothing
-#endif
             }
         ignoreExceptions $ addAttachMessage pipes ph
         void $ forkIO $ ignoreExceptions $

--- a/src/Keter/Main.hs
+++ b/src/Keter/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -54,11 +53,6 @@ import System.Posix.Files (getFileStatus, modificationTime)
 import System.Posix.Signals (Handler(Catch), installHandler, sigHUP)
 import System.Posix.User
        (getUserEntryForID, getUserEntryForName, userGroupID, userID, userName)
-
-#ifdef SYSTEM_FILEPATH
-import Filesystem.Path qualified as FP (FilePath)
-import Filesystem.Path.CurrentOS (encodeString)
-#endif
 
 keter :: FilePath -- ^ root directory or config file
       -> [FilePath -> IO Plugin]
@@ -191,14 +185,14 @@ startWatching appMan = do
                 e' <-
                     case e of
                         FSN.Removed fp _ _ -> do
-                            rio $ $logInfo $ "Watched file removed: " <> T.pack (fromFilePath fp)
-                            return $ Left $ fromFilePath fp
+                            rio $ $logInfo $ "Watched file removed: " <> T.pack fp
+                            return $ Left fp
                         FSN.Added fp _ _ -> do
-                            rio $ $logInfo $ "Watched file added: " <> T.pack (fromFilePath fp)
-                            return $ Right $ fromFilePath fp
+                            rio $ $logInfo $ "Watched file added: " <> T.pack fp
+                            return $ Right fp
                         FSN.Modified fp _ _ -> do
-                            rio $ $logInfo $ "Watched file modified: " <> T.pack (fromFilePath fp)
-                            return $ Right $ fromFilePath fp
+                            rio $ $logInfo $ "Watched file modified: " <> T.pack fp
+                            return $ Right fp
                         _ -> do
                             rio $ $logInfo $ "Watched file unknown" <> T.pack mempty
                             return $ Left []
@@ -212,17 +206,6 @@ startWatching appMan = do
                 time <- modificationTime <$> getFileStatus bundle
                 return (getAppname bundle, (bundle, time))
             rio $ AppMan.reloadAppList newMap
-
-
--- compatibility with older versions of fsnotify which used
--- 'Filesystem.Path'
-#ifdef SYSTEM_FILEPATH
-fromFilePath :: FP.FilePath -> String
-fromFilePath = encodeString
-#else
-fromFilePath :: forall a. a -> a
-fromFilePath = id
-#endif
 
 listDirectoryTree :: FilePath -> IO [FilePath]
 listDirectoryTree fp = do

--- a/src/Keter/Proxy.hs
+++ b/src/Keter/Proxy.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/src/Keter/Rewrite.hs
+++ b/src/Keter/Rewrite.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 


### PR DESCRIPTION
The project used CPP to conditionally support legacy packages. It's time to drop support for these, which means we no longer need to use CPP, nor the system-filepath cabal flag.

This also raises the lower bound for `process` to 1.6.

---

Worked on this during https://github.com/Thaigersprint/thaigersprint-2025/issues/1.