### PR TITLE
Remove ghc-prim

### DIFF
--- a/keter.cabal
+++ b/keter.cabal
@@ -76,9 +76,6 @@ library
     , yaml                  >=0.8.4    && <0.12
     , zlib                  >=0.6.2    && <0.7     || ^>=0.7.0
 
-  if impl(ghc <7.6)
-    build-depends: ghc-prim
-
   exposed-modules:
     Keter.App
     Keter.AppManager


### PR DESCRIPTION
This dependency was conditional on GHC 7.6 or earlier, which is now ancient. We can just remove it.