### PR TITLE
Add first integrated test with nixosTest VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ cabal.sandbox.config
 *.sublime-*
 dist-newstyle/
 .pre-commit-config.yaml
+result
+.nixos-test-history

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,8 @@
                 stylish-haskell.enable = true;
               };
             };
+
+            integratedTests = pkgs.callPackage ./vm.nix { inherit self; };
           };
 
           devShells.default = pkgs.haskellPackages.shellFor {

--- a/keter.nix
+++ b/keter.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.keter-ng;
+
+in
+{
+  options.services.keter-ng = {
+    enable = lib.mkEnableOption (lib.mdDoc ''
+      keter — a web app deployment manager.
+    '');
+
+    root = lib.mkOption {
+      type = lib.types.str;
+      default = "/opt/keter";
+      description = lib.mdDoc "Mutable state folder for keter";
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.haskellPackages.keter;
+      defaultText = lib.literalExpression "pkgs.haskellPackages.keter";
+      description = lib.mdDoc "The keter package to be used";
+    };
+
+    globalKeterConfig = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = lib.mdDoc ''
+        A custom YAML configuration for Keter. This content will be directly
+        written to the `keter-config.yml` file without modification. See
+        <https://github.com/snoyberg/keter/blob/master/etc/keter-config.yaml>
+        for reference.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    let
+      incoming = "${cfg.root}/incoming";
+
+      globalKeterConfigFile = pkgs.writeTextFile {
+        name = "keter-config.yml";
+        text = cfg.globalKeterConfig;
+      };
+    in
+    {
+      systemd.services.keter-ng = {
+        description = "keter app loader";
+        script = ''
+          set -xe
+          mkdir -p ${incoming}
+          ${lib.getExe cfg.package} ${globalKeterConfigFile};
+        '';
+        wantedBy = [ "multi-user.target" "nginx.service" ];
+
+        serviceConfig = {
+          Restart = "always";
+          RestartSec = "10s";
+        };
+
+        after = [
+          "network.target"
+          "local-fs.target"
+          "postgresql.service"
+        ];
+      };
+    }
+  );
+}
+

--- a/vm.nix
+++ b/vm.nix
@@ -1,0 +1,37 @@
+{ testers, self }:
+
+testers.nixosTest {
+  name = "vm-test";
+
+  nodes.server = { ... }: {
+
+    imports = [
+      ./keter.nix
+    ];
+
+    nix.settings = {
+      experimental-features = [ "nix-command" "flakes" ];
+      auto-optimise-store = true;
+    };
+
+    services.keter-ng = {
+      enable = true;
+      package = self.packages.x86_64-linux.keter;
+      globalKeterConfig = ''
+        root: /opt/keter
+        rotate-logs: false
+        listeners:
+          - host: "*4"
+            port: 80
+      '';
+    };
+
+  };
+
+  testScript = ''
+    server.start()
+    server.wait_for_unit("keter-ng.service")
+    server.wait_for_open_port(80)
+    server.succeed("curl localhost")
+  '';
+}


### PR DESCRIPTION
This is a first pass at adding integrated tests for keter. This works by spinning up a NixOS virtual machine, running keter as a systemd service on it, and probing it with HTTP requests.

This work brings us closer to resolving https://github.com/snoyberg/keter/issues/258.

---

Working on this during https://github.com/Thaigersprint/thaigersprint-2025/issues/1.