### PR TITLE
Widen aeson upper bound to allow 2.3.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.6
+- Widen `aeson` upper bound to allow 2.3.x for Stackage compatibility
+
 ## 2.3.5
 - Bump containers
 

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               keter
-version:            2.3.5
+version:            2.3.6
 synopsis:
   Web application deployment manager, focusing on Haskell web frameworks. It mitigates downtime.
 
@@ -27,7 +27,7 @@ library
   default-language:   Haskell98
   default-extensions: ImportQualifiedPost
   build-depends:
-    , aeson                 >=2.0.0    && <2.2     || ^>=2.2.0.0
+    , aeson                 >=2.0.0    && <2.2     || ^>=2.2.0.0 || ^>=2.3.0.0
     , array                 >=0.5.4    && <0.6
     , async                 >=2.2.4    && <2.3
     , attoparsec            >=0.14.4   && <0.15


### PR DESCRIPTION
## Summary
- Widen `aeson` dependency bound from `^>=2.2.0.0` to include `^>=2.3.0.0`
- Bump version to 2.3.6
- Update ChangeLog.md

Fixes compatibility with Stackage's upcoming aeson 2.3 bump.

Ref: https://github.com/commercialhaskell/stackage/issues/8016

🤖 Generated with [Claude Code](https://claude.com/claude-code)