### PR TITLE
Fix misleading usage message and silent dir creation for bad config path

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.4.1
+
+- Fix misleading usage message and silent directory creation when the
+  config path does not exist. The argument is now described as a keter
+  home directory or config file, and a path that is neither an existing
+  file nor an existing directory is reported as an error instead of being
+  silently adopted as the keter home directory. [199](https://github.com/snoyberg/keter/issues/199)
+
 ## 2.4.0
 
 - HTTP responses no longer contain the Server header. [338](https://github.com/snoyberg/keter/issues/338)

--- a/keter.cabal
+++ b/keter.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               keter
-version:            2.4.0
+version:            2.4.1
 synopsis:
   Web application deployment manager, focusing on Haskell web frameworks. It mitigates downtime.
 

--- a/src/Keter/Common.hs
+++ b/src/Keter/Common.hs
@@ -65,6 +65,7 @@ data KeterException = CannotParsePostgres FilePath
                     | NoPortsAvailable
                     | InvalidConfigFile Data.Yaml.ParseException
                     | InvalidKeterConfigFile !FilePath !Data.Yaml.ParseException
+                    | ConfigPathDoesNotExist !FilePath
                     | CannotReserveHosts !AppId !(Map Host AppId)
                     | FileNotExecutable !FilePath
                     | ExecutableNotFound !FilePath

--- a/src/Keter/Main.hs
+++ b/src/Keter/Main.hs
@@ -83,15 +83,18 @@ runKeterConfigReader :: MonadIO m
                      -> ReaderT KeterConfig m a
                      -> m a
 runKeterConfigReader input ctx = do
-    exists <- liftIO $ doesFileExist input
+    isFile <- liftIO $ doesFileExist input
+    isDir <- liftIO $ doesDirectoryExist input
     config <- liftIO $
-        if exists
+        if isFile
             then do
                 eres <- decodeFileRelative input
                 case eres of
                     Left e -> throwIO $ InvalidKeterConfigFile input e
                     Right x -> return x
-            else return defaultKeterConfig { kconfigDir = input }
+            else if isDir
+                then return defaultKeterConfig { kconfigDir = input }
+                else throwIO $ ConfigPathDoesNotExist input
     runReaderT ctx config
 
 -- | Running the Keter logger requires a context with access to a KeterConfig, hence the

--- a/src/main/keter.hs
+++ b/src/main/keter.hs
@@ -23,4 +23,4 @@ main = do
 printUsage :: IO ()
 printUsage = do
     pn <- getProgName
-    error $ "Usage: " ++ pn ++ " <config file>"
+    error $ "Usage: " ++ pn ++ " <keter-home-directory | config-file>"


### PR DESCRIPTION
Fixes #199.

Running `keter <path>` with a path intended as a config file that doesn't exist silently treated that path as the keter home directory and populated a subdirectory tree inside it — leaving users hunting for their logs and config. The usage message added to the confusion by calling the argument `<config file>` when keter expects the home directory (or a config file).

This distinguishes three cases explicitly in `runKeterConfigReader`: an existing file is decoded as config, an existing directory is used as `kconfigDir`, and a path that is neither now throws a new `ConfigPathDoesNotExist` exception instead of being silently adopted. The usage string is updated to describe both accepted forms.

Bumps to 2.4.1 with a changelog entry.